### PR TITLE
Setup tweeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # plottr: (live) plotting
 
-A simple GUI tool for plotting measurement data (e.g., for live plotting). It runs as a standalone server, and data can be sent to it via a network socket, which makes it fairly independent of the tools used to measure. 
+A simple GUI tool for plotting measurement data (e.g., for live plotting). It runs as a standalone server, and data can
+be sent to it via a network socket, which makes it fairly independent of the tools used to measure. 
 
 There's little documentation at this point, but there is a list of examples in the notebooks in the doc/ folder.
 
 ## Usage: 
-* run the standalone program plottr.py (e.g. through the .bat file)
-* In your working process (i.e., ipython session, jupyter notebook, ...) use one of the client tools to package the data correctly (or do it yourself) and send it (see examples!). 
+* run the standalone script plottr.exe, alternatively this can be started in a subprocess within your 
+  working python session with `plottr.start_listener()`
+* In your working process (i.e., ipython session, jupyter notebook, ...) use one of the client tools to package the 
+  data correctly (or do it yourself) and send it (see examples!). 
 * If you're using qcodes with the dataset v2, there's also a subscriber that 
-you can use with the dataset (see examples!)
+  you can use with the dataset (see examples!)
 
 # inspectr: QCoDeS dataset inspection
 
@@ -17,10 +20,10 @@ files.
 
 ## Usage:
 
-* start the standalone program inspectr.py
+* start the standalone program inspectr.exe
 * drag and drop a .db file into the main window after launching
 * if plottr is running, a double click on a row in the dataset table in the 
-inspectr window will send the data to plottr where it is visualized.
+  inspectr window will send the data to plottr where it is visualized.
 
 # Requirements:
 * python >= 3.6 (f-strings...)

--- a/inspectr.py
+++ b/inspectr.py
@@ -1,17 +1,4 @@
-import sys
-from PyQt5.QtWidgets import QApplication
-from plottr.qcodes_dataset_inspectr import InspectrMain
+from plottr.qcodes_dataset_inspectr import console_entry
 
 if __name__ == "__main__":
-    nargs = len(sys.argv) - 1
-    if nargs > 0:
-        fp = sys.argv[1]
-    else:
-        fp = None
-
-    app = QApplication(sys.argv)
-    main = InspectrMain()
-    main.show()
-    main.setFilePath(fp)
-
-    sys.exit(app.exec_())
+    console_entry()

--- a/plottr.py
+++ b/plottr.py
@@ -1,9 +1,4 @@
-import sys
-from PyQt5.QtWidgets import QApplication
-from plottr.plottr import PlottrMain
+from plottr.plottr import console_entry
 
 if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    main = PlottrMain()
-    main.show()
-    sys.exit(app.exec_())
+    console_entry()

--- a/plottr/plottr.py
+++ b/plottr/plottr.py
@@ -768,3 +768,13 @@ class PlottrMain(QMainWindow):
     def dataWindowClosed(self, dataId):
         self.dataHandlers[dataId].close()
         del self.dataHandlers[dataId]
+
+
+def console_entry():
+    """
+    Entry point for launching a Plottr app from a console script
+    """
+    app = QApplication(sys.argv)
+    main = PlottrMain()
+    main.show()
+    sys.exit(app.exec_())

--- a/plottr/qcodes_dataset_inspectr.py
+++ b/plottr/qcodes_dataset_inspectr.py
@@ -137,3 +137,21 @@ class InspectrMain(QMainWindow):
         sender = DataSender("{} # run ID = {}".format(self.filepath, runId))
         sender.data['datasets'] = data
         sender.sendData()
+
+
+def console_entry() -> None:
+    """
+    Entry point for launching a Inspectr app from a console script
+    """
+    nargs = len(sys.argv) - 1
+    if nargs > 0:
+        fp = sys.argv[1]
+    else:
+        fp = None
+
+    app = QApplication(sys.argv)
+    main = InspectrMain()
+    main.show()
+    main.setFilePath(fp)
+
+    sys.exit(app.exec_())

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,7 @@ setup(
         'pandas>=0.22',
         'xarray',
     ],
+    entry_points={'console_scripts': ['plottr=plottr.plottr:console_entry',
+                                      'inspectr=plottr.qcodes_dataset_inspectr'
+                                      ':console_entry']}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='plottr',
@@ -7,6 +7,7 @@ setup(
     author='Wolfgang Pfaff',
     author_email='wolfgangpfff@gmail.com',
     url='https://github.com/wpfff',
+    packages=find_packages(),
     install_requires=[
         'pandas>=0.22',
         'xarray',


### PR DESCRIPTION
* Use find_package to grab actual python files to be installed. Makes regular pip install work as expected.
* Add scripts that will be installed and put on path. This removed the need for bat files and cloning the repo to grab them
* Mention this in the readme along with the subprocess launcher used in the notebook

@wpfff @astafan8 