### PR TITLE
Fix issue with gridding when axis-order was non-standard

### DIFF
--- a/plottr/utils/misc.py
+++ b/plottr/utils/misc.py
@@ -1,0 +1,56 @@
+"""misc.py
+
+Various utility functions.
+"""
+
+from typing import List, Tuple
+
+
+def reorder_indices(lst: List, target: List) -> Tuple[int]:
+    """
+    Determine how to bring a list with unique entries to a different order.
+
+    Supports only lists of strings.
+
+    :param lst: input list
+    :param target: list in the desired order
+    :return: the indices that will reorder the input to obtain the target.
+    :raises: ``ValueError`` for invalid inputs.
+    """
+    if set([type(i) for i in lst]) != {str}:
+        raise ValueError('Only lists of strings are supported')
+    if len(set(lst)) < len(lst):
+        raise ValueError('Input list elements are not unique.')
+    if set(lst) != set(target) or len(lst) != len(target):
+        raise ValueError('Contents of input and target do not match.')
+
+    idxs = []
+    for elt in target:
+        idxs.append(lst.index(elt))
+
+    return tuple(idxs)
+
+
+def reorder_indices_from_new_positions(lst: List[str], **pos: int) \
+        -> Tuple[int]:
+    """
+    Determine how to bring a list with unique entries to a different order.
+
+    :param lst: input list (of strings)
+    :param pos: new positions in the format ``element = new_position``.
+                non-specified elements will be adjusted automatically.
+    :return: the indices that will reorder the input to obtain the target.
+    :raises: ``ValueError`` for invalid inputs.
+    """
+    if set([type(i) for i in lst]) != {str}:
+        raise ValueError('Only lists of strings are supported')
+    if len(set(lst)) < len(lst):
+        raise ValueError('Input list elements are not unique.')
+
+    target = lst.copy()
+    for item, newidx in pos.items():
+        oldidx = target.index(item)
+        del target[oldidx]
+        target.insert(newidx, item)
+
+    return reorder_indices(lst, target)

--- a/plottr/utils/num.py
+++ b/plottr/utils/num.py
@@ -139,7 +139,7 @@ def find_direction_period(vals: np.ndarray, ignore_last: bool = False) \
         return int(periods[0])
 
 
-def shape_and_order_from_direction_change(**axes: np.ndarray) \
+def guess_grid_from_sweep_direction(**axes: np.ndarray) \
         -> Union[None, Tuple[List[str], Tuple[int]]]:
     """
     Try to determine order and shape of a set of axes data

--- a/plottr/utils/num.py
+++ b/plottr/utils/num.py
@@ -2,7 +2,7 @@
 
 Tools for numerical operations.
 """
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Union, List
 import numpy as np
 
 
@@ -93,3 +93,101 @@ def array1d_to_meshgrid(arr: Sequence, target_shape: Tuple[int],
         arr = np.append(arr, fill)
 
     return arr.reshape(target_shape)
+
+
+def find_direction_period(vals: np.ndarray, ignore_last: bool = False) \
+        -> Union[None, int]:
+    """
+    Find the period with which the values in an array change direction.
+
+    :param vals: the axes values (1d array)
+    :param ignore_last: if True, we'll ignore the last value when determining
+                        if the period is unique (useful for incomplete data),
+    :return: None if we could not determine a unique period.
+             The period, i.e., the number of elements after which
+             the more common direction is changed.
+    """
+    direction = np.sign(vals[1:] - vals[:-1])
+    ups = np.where(direction == 1)[0]
+    downs = np.where(direction == -1)[0]
+
+    if len(ups) > len(downs):
+        switches = downs
+    else:
+        switches = ups
+
+    if len(switches) == 0:
+        return vals.size
+    elif len(switches) == 1:
+        if switches[0] >= (vals.size / 2.) - 1:
+            return switches[0] + 1
+        else:
+            return None
+
+    if switches[-1] < vals.size - 1:
+        switches = np.append(switches, vals.size-1)
+    periods = (switches[1:] - switches[:-1])
+
+    if ignore_last and periods[-1] < periods[0]:
+        periods = periods[:-1]
+
+    if len(set(periods)) > 1:
+        return None
+    elif len(periods) == 0:
+        return vals.size
+    else:
+        return int(periods[0])
+
+
+def shape_and_order_from_direction_change(**axes: np.ndarray) \
+        -> Union[None, Tuple[List[str], Tuple[int]]]:
+    """
+    Try to determine order and shape of a set of axes data
+    (such as flattened meshgrid data).
+
+    Analyzes the periodicity (in sweep direction) of the given set of axes
+    values, and use that information to infer the shape of the dataset,
+    and the order of the axes, given from slowest to fastest.
+
+    :param axes: all axes values as keyword args, given as 1d numpy arrays.
+    :return: None, if we cannot infer a shape that makes sense.
+             Sorted list of axes names, and shape tuple for the dataset.
+    :raises: `ValueError` for incorrect input
+    """
+    periods = []
+    names = []
+    size = None
+
+    if len(axes) < 1:
+        raise ValueError("Empty input.")
+
+    for name, vals in axes.items():
+        if len(np.array(vals).shape) > 1:
+            raise ValueError(
+                f"Expect 1-dimensional axis data, not {np.array(vals).shape}")
+        if size is None:
+            size = np.array(vals).size
+        else:
+            if size != np.array(vals).size:
+                raise ValueError("Non-matching array sizes.")
+
+        period = find_direction_period(vals)
+        if period is not None:
+            periods.append(period)
+            names.append(name)
+        else:
+            return None
+
+    order = np.argsort(periods)
+    periods = np.array(periods)[order]
+    names = np.array(names)[order]
+
+    divisor = 1
+    for i, p in enumerate(periods.copy()):
+        periods[i] //= divisor
+        divisor *= int(periods[i])
+
+    if np.prod(periods) != size or divisor != size:
+        return None
+
+    return names[::-1].tolist(), tuple(periods[::-1])

--- a/test/pytest/test_misc_utils.py
+++ b/test/pytest/test_misc_utils.py
@@ -1,0 +1,14 @@
+from plottr.utils import misc
+
+
+def test_list_reorder():
+    """Basic testing of list-reordering"""
+    lst = ['a', 'b', 'f', 'z', 'x']
+    neworder = ['b', 'f', 'x', 'z', 'a']
+    order = misc.reorder_indices(lst, neworder)
+    assert [lst[o] for o in order] == neworder
+
+    order = misc.reorder_indices_from_new_positions(
+        lst, b=0, f=1, x=2, z=3)
+    assert [lst[o] for o in order] == neworder
+

--- a/test/pytest/test_numtools.py
+++ b/test/pytest/test_numtools.py
@@ -36,3 +36,32 @@ def test_array_reshape():
     out = num.array1d_to_meshgrid(a, (3, 3))
     assert out.shape == (3, 3)
     assert num.arrays_equal(out, a[:9].reshape(3, 3))
+
+
+def test_find_direction_period():
+    """Test period finding in the direction"""
+
+    arr = np.concatenate((np.arange(5), np.arange(5))).astype(float)
+    assert num.find_direction_period(arr) == 5
+
+    arr[1] = np.nan
+    arr[6] = None
+    assert num.find_direction_period(arr) == 5
+
+    arr = np.array([1, 2, 3, 1, 2, 1, 2, 3])
+    assert num.find_direction_period(arr) is None
+
+
+def test_find_shape_from_directions():
+    """Test finding the shape of a dataset by analyzing axes values"""
+
+    x = np.arange(5)
+    y = np.arange(7, 3, -1)
+    xx, yy = np.meshgrid(x, y, indexing='ij')
+
+    ret = num.shape_and_order_from_direction_change(
+        x=xx.reshape(-1), y=yy.reshape(-1)
+    )
+    assert ret[0] == ['x', 'y']
+    assert ret[1] == xx.shape
+

--- a/test/pytest/test_numtools.py
+++ b/test/pytest/test_numtools.py
@@ -59,7 +59,7 @@ def test_find_shape_from_directions():
     y = np.arange(7, 3, -1)
     xx, yy = np.meshgrid(x, y, indexing='ij')
 
-    ret = num.shape_and_order_from_direction_change(
+    ret = num.guess_grid_from_sweep_direction(
         x=xx.reshape(-1), y=yy.reshape(-1)
     )
     assert ret[0] == ['x', 'y']

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -86,8 +86,9 @@ def test_update_qcloader(qtbot):
 
         z_in = zz.reshape(-1)[:nresults]
         z_out = ddict.data_vals('z')
-        assert z_in.size == z_out.size
-        assert np.allclose(z_in, z_out, atol=1e-15)
+        if z_out is not None:
+            assert z_in.size == z_out.size
+            assert np.allclose(z_in, z_out, atol=1e-15)
 
     # insert data in small chunks, and check
     while True:


### PR DESCRIPTION
due to the default behavior of np.reshape there was no good support for gridding data that had a different order of the axes than slowest -> fastest. Basic functionality now implemented.

Fixes #29.