### PR TITLE
Ignore extra independent parameters

### DIFF
--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -174,7 +174,8 @@ def ds_to_datadict(ds: DataDict, start: Optional[int] = None,
     struct = get_ds_structure(ds)
     datadict = DataDict(**struct)
     for k, v in data.items():
-        datadict[k]['values'] = data[k]
+        if k in datadict:
+            datadict[k]['values'] = data[k]
 
     datadict.validate()
     return datadict


### PR DESCRIPTION
If there are extra independent parameters present in the dataset,
ignore them.

Hey @wpfff I just started using plottr and I'm really liking it! I have an issue with the ds_to_datadict failing if there are extra independent parameters present in the measurement run. 
Eg:
```
meas = Measurement(exp, station)
meas.register_parameter(x)
meas.register_custom_parameter("foo", label="An extra independant param")
meas.register_parameter(y, setpoints=(x,))
meas.register_parameter(y2, setpoints=(x,))
meas.write_period = 2

with meas.run() as datasaver:
    for xval, yval, y2val in simple_1d_sweep():
        datasaver.add_result(
            (x, xval),
            (y, yval),
            (y2, y2val),
            ("foo", 1)
        )
```

This snippet will throw a key error as "foo" doesn't show up in the datadict. This patch works for me, but you might have a better way to deal with this?

Cheers