### PR TITLE
Use only public QCoDeS API (mostly in inspectr app)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 .ipynb_checkpoints
-*.db
 *.egg-info
 __pycache__
 *.egg-info/

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -11,7 +11,7 @@ from pyqtgraph.Qt import QtGui, QtCore
 
 from .. import log as plottrlog
 from ..data.qcodes_dataset import (get_runs_from_db_as_dataframe,
-                                   get_ds_info_from_path,)
+                                   get_ds_structure, load_dataset_from)
 from plottr.gui.widgets import MonitorIntervalInput, FormLayoutWrapper
 
 from .autoplot import autoplotQcodesDataset
@@ -413,8 +413,8 @@ class QCodesDBInspector(QtGui.QMainWindow):
 
     @QtCore.pyqtSlot(int)
     def setRunSelection(self, runId):
-        info = get_ds_info_from_path(self.filepath, runId, get_structure=True)
-        structure = info['structure']
+        ds = load_dataset_from(self.filepath, runId)
+        structure = get_ds_structure(ds)
         for k, v in structure.items():
             v.pop('values')
         contentInfo = {'data' : structure}

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -5,9 +5,8 @@ Dealing with qcodes dataset (the database) data in plottr.
 """
 import os
 from sqlite3 import Connection
-from typing import Dict, List, Set, Union, Optional, TYPE_CHECKING
+from typing import Dict, List, Set, Union, TYPE_CHECKING
 
-import numpy as np
 import pandas as pd
 
 from qcodes.dataset.data_set import load_by_id

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -4,7 +4,6 @@ qcodes_dataset.py
 Dealing with qcodes dataset (the database) data in plottr.
 """
 import os
-from sqlite3 import Connection
 from typing import Dict, List, Set, Union, TYPE_CHECKING
 
 import pandas as pd
@@ -72,16 +71,13 @@ def get_ds_structure(ds: 'DataSet'):
     return structure
 
 
-def get_ds_info(conn: Connection, run_id: int,
-                get_structure: bool = True) -> Dict[str, str]:
+def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> Dict[str, str]:
     """
-    Get some info on a run in dict form from a db connection and runId.
+    Get some info on a DataSet in dict.
 
     if get_structure is True: return the datastructure in that dataset
     as well (key is `structure' then).
     """
-    ds = load_by_id(run_id=run_id, conn=conn)
-
     ret = {}
     ret['experiment'] = ds.exp_name
     ret['sample'] = ds.sample_name
@@ -118,7 +114,7 @@ def get_ds_info_from_path(path: str, run_id: int,
     """
     initialise_or_create_database_at(path)
     ds = load_by_id(run_id=run_id)
-    return get_ds_info(ds.conn, run_id, get_structure=get_structure)
+    return get_ds_info(ds, get_structure=get_structure)
 
 
 def get_runs_from_db(path: str, start: int = 0,
@@ -146,8 +142,7 @@ def get_runs_from_db(path: str, start: int = 0,
 
     for run_id in run_ids:
         ds = load_by_id(run_id)
-        overview[run_id] = get_ds_info(ds.conn, run_id,
-                                       get_structure=get_structure)
+        overview[run_id] = get_ds_info(ds, get_structure=get_structure)
 
     return overview
 

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -226,8 +226,9 @@ class QCodesDSLoader(Node):
 
             ds = load_dataset_from(path, runId)
 
-            guid = ds.guid
             if ds.number_of_results > self.nLoadedRecords:
+
+                guid = ds.guid
                 title = f"{os.path.split(path)[-1]} | " \
                         f"run ID: {runId} | GUID: {guid}"
                 info = """Started: {}

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -173,7 +173,7 @@ def ds_to_datadicts(ds: 'DataSet') -> Dict[str, DataDict]:
     pdata = ds.get_parameter_data()
     for p, spec in ds.paramspecs.items():
         if spec.depends_on != '':
-            axes = spec.depends_on_ # .split(', ')
+            axes = spec.depends_on_
             data = dict()
             data[p] = dict(unit=spec.unit, axes=axes, values=pdata[p][p])
             for ax in axes:

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -85,8 +85,12 @@ def get_ds_info(conn: Connection, run_id: int,
         ret['completed time'] = ''
 
     _start_ts = ds.run_timestamp()
-    ret['started date'] = _start_ts[:10]
-    ret['started time'] = _start_ts[11:]
+    if _start_ts is not None:
+        ret['started date'] = _start_ts[:10]
+        ret['started time'] = _start_ts[11:]
+    else:
+        ret['started date'] = ''
+        ret['started time'] = ''
 
     if get_structure:
         ret['structure'] = get_ds_structure(ds)

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -106,15 +106,16 @@ def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> Dict[str, str]:
     return ret
 
 
-def get_ds_info_from_path(path: str, run_id: int,
-                          get_structure: bool = True):
+def load_dataset_from(path: str, run_id: int) -> 'DataSet':
     """
-    Convenience function that determines the dataset from `path` and
-    `run_id`, then calls `get_ds_info`.
+    Loads ``DataSet`` with the given ``run_id`` from a database file that
+    is located in in the given ``path``.
+
+    Note that after the call to this function, the database location in the
+    qcodes config of the current python process is changed to ``path``.
     """
     initialise_or_create_database_at(path)
-    ds = load_by_id(run_id=run_id)
-    return get_ds_info(ds, get_structure=get_structure)
+    return load_by_id(run_id=run_id)
 
 
 def get_runs_from_db(path: str, start: int = 0,
@@ -223,8 +224,7 @@ class QCodesDSLoader(Node):
         if None not in self._pathAndId:
             path, runId = self._pathAndId
 
-            initialise_or_create_database_at(path)
-            ds = load_by_id(run_id=runId)
+            ds = load_dataset_from(path, runId)
 
             guid = ds.guid
             if ds.number_of_results > self.nLoadedRecords:

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -191,19 +191,6 @@ def ds_to_datadict(ds: 'DataSet') -> DataDictBase:
     return ddict
 
 
-def datadict_from_path_and_run_id(path: str, run_id: int) -> DataDictBase:
-    """
-    Load a qcodes dataset as a DataDict.
-
-    :param path: file path of the qcodes .db file.
-    :param run_id: run_id of the dataset.
-    :return: DataDict containing the data.
-    """
-    initialise_or_create_database_at(path)
-    ds = load_by_id(run_id=run_id)
-    return ds_to_datadict(ds)
-
-
 ### qcodes dataset loader node
 
 class QCodesDSLoader(Node):

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -20,12 +20,12 @@ def test_load_2dsoftsweep():
 
     N = 5
     m = qc.Measurement(exp=exp)
-    m.register_custom_parameter('x')
+    m.register_custom_parameter('x', unit='cm')
     m.register_custom_parameter('y')
 
     # check that unused parameters don't mess with
     m.register_custom_parameter('foo')
-    dd_expected = DataDict(x=dict(values=np.array([])),
+    dd_expected = DataDict(x=dict(values=np.array([]), unit='cm'),
                            y=dict(values=np.array([])))
     for n in range(N):
         m.register_custom_parameter(f'z_{n}', setpoints=['x', 'y'])

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -6,11 +6,11 @@ from plottr.data.datadict import DataDict
 from plottr.utils import testdata
 from plottr.node.tools import linearFlowchart
 from plottr.data.qcodes_dataset import (
-    datadict_from_path_and_run_id,
     QCodesDSLoader,
     get_ds_structure,
     get_ds_info,
-    get_runs_from_db)
+    get_runs_from_db,
+    ds_to_datadict)
 
 DBPATH = './test_qc_saveandload.db'
 
@@ -41,8 +41,7 @@ def test_load_2dsoftsweep():
             dd_expected.add_data(**result)
 
     # retrieve data as data dict
-    run_id = datasaver.dataset.captured_run_id
-    ddict = datadict_from_path_and_run_id(DBPATH, run_id)
+    ddict = ds_to_datadict(datasaver.dataset)
     assert ddict == dd_expected
 
 

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -110,8 +110,7 @@ def test_get_ds_info():
     with m.run() as datasaver:
         dataset = datasaver.dataset
 
-        ds_info_with_empty_timestamps = get_ds_info(dataset.conn,
-                                                    dataset.run_id,
+        ds_info_with_empty_timestamps = get_ds_info(dataset,
                                                     get_structure=False)
         assert ds_info_with_empty_timestamps['completed date'] == ''
         assert ds_info_with_empty_timestamps['completed time'] == ''
@@ -131,14 +130,14 @@ def test_get_ds_info():
         'records': 0
     }
 
-    ds_info = get_ds_info(dataset.conn, dataset.run_id, get_structure=False)
+    ds_info = get_ds_info(dataset, get_structure=False)
 
     assert ds_info == expected_ds_info
 
     expected_ds_info_with_structure = expected_ds_info.copy()
     expected_ds_info_with_structure['structure'] = get_ds_structure(dataset)
 
-    ds_info_with_structure = get_ds_info(dataset.conn, dataset.run_id)
+    ds_info_with_structure = get_ds_info(dataset)
 
     assert ds_info_with_structure == expected_ds_info_with_structure
 
@@ -180,8 +179,7 @@ def test_get_runs_from_db(tmp_path):
         dataset2 = datasaver.dataset
 
     # Prepare an expected overview of the created database
-    expected_overview = {ds.run_id: get_ds_info(ds.conn, ds.run_id,
-                                                get_structure=False)
+    expected_overview = {ds.run_id: get_ds_info(ds, get_structure=False)
                          for ds in (dataset11, dataset12, dataset2)}
 
     # Get the actual overview of the created database
@@ -192,7 +190,7 @@ def test_get_runs_from_db(tmp_path):
 
     # Prepare an expected overview of the created database WITH STRUCTURE
     expected_overview_with_structure = {
-        ds.run_id: get_ds_info(ds.conn, ds.run_id, get_structure=True)
+        ds.run_id: get_ds_info(ds, get_structure=True)
         for ds in (dataset11, dataset12, dataset2)
     }
 


### PR DESCRIPTION
This PR makes `plottr.data.qcodes_dataset` module use ONLY PUBLIC QCoDeS API. Additionally, useless functions of that module are removed. Also, that module got extra test coverage. For more information, see commit messages.