### PR TITLE
Add measurement name column to inspectr

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -104,7 +104,7 @@ class DateList(QtGui.QListWidget):
 
 class RunList(QtGui.QTreeWidget):
 
-    cols = ['Run ID', 'Experiment', 'Sample', 'Started', 'Completed', 'Records']
+    cols = ['Run ID', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records']
 
     runSelected = QtCore.pyqtSignal(int)
     runActivated = QtCore.pyqtSignal(int)
@@ -122,6 +122,7 @@ class RunList(QtGui.QTreeWidget):
         lst = [str(runId)]
         lst.append(vals.get('experiment', ''))
         lst.append(vals.get('sample', ''))
+        lst.append(vals.get('name', ''))
         lst.append(vals.get('started date', '') + ' ' + vals.get('started time', ''))
         lst.append(vals.get('completed date', '') + ' ' + vals.get('completed time', ''))
         lst.append(str(vals.get('records', '')))

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -73,6 +73,7 @@ def get_ds_info(conn: Connection, run_id: int,
     ret = {}
     ret['experiment'] = ds.exp_name
     ret['sample'] = ds.sample_name
+    ret['name'] = ds.name
 
     _complete_ts = ds.completed_timestamp()
     if _complete_ts is not None:


### PR DESCRIPTION
Might not be so useful if all measurements are named 'results' (i.e. if the `Measurement.name` attribute is not set in Qcodes during the measurement), but otherwise can be really handy for differentiating measurements in the same experiment.

Adding the name column makes a scroll bar appear at the bottom with the current default window size, which is maybe not so nice. A further development could be to lessen clutter by allowing hiding some columns. For example, right now I only have one experiment in the database so that column is pretty much useless. Should be pretty straightforward to do using QTreeView, I could make a separate PR for that.