### PR TITLE
Fix/dd5test

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -255,7 +255,7 @@ def datadict_from_hdf5(basepath: str, groupname: str = 'data',
 
         grp = f[groupname]
         keys = list(grp.keys())
-        lens = [len(grp[k].value) for k in keys]
+        lens = [len(grp[k][:]) for k in keys]
 
         if len(set(lens)) > 1:
             if not ignore_unequal_lengths:
@@ -285,7 +285,7 @@ def datadict_from_hdf5(basepath: str, groupname: str = 'data',
                     entry['unit'] = deh5ify(ds.attrs['unit'])
 
                 if not structure_only:
-                    entry['values'] = ds.value[startidx:stopidx]
+                    entry['values'] = ds[startidx:stopidx]
 
                 # and now the meta data
                 for attr in ds.attrs:

--- a/test/pytest/test_ddh5.py
+++ b/test/pytest/test_ddh5.py
@@ -6,7 +6,7 @@ from plottr.data import datadict as dd
 from plottr.data import datadict_storage as dds
 from plottr.node.tools import linearFlowchart
 
-FN = './test_ddh5_data.dd.h5'
+FN = './test_ddh5_data.ddh5'
 
 
 def _clean_from_file(datafromfile):


### PR DESCRIPTION
dataset.value is now deprecated in h5py. 
removed it's usaged in the ddh5 storage module. Fixes #71.

also small cosmetic fix in file naming (in the pytest file)