### PR TITLE
Added a treeview of snapshot at the bottom of autoplot for qcodes datasets

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -20,8 +20,10 @@ from ..node.grid import DataGridder, GridOption
 from ..node.dim_reducer import XYSelector
 from ..node.filter.correct_offset import SubtractAverage
 from ..plot.mpl import PlotNode, AutoPlot
-from ..gui.widgets import MonitorIntervalInput, PlotWindow
+from ..gui.widgets import MonitorIntervalInput, PlotWindow, SnapshotWidget
 from ..gui.tools import flowchartAutoPlot
+
+
 
 __author__ = 'Wolfgang Pfaff'
 __license__ = 'MIT'
@@ -110,6 +112,7 @@ class AutoPlotMainWindow(PlotWindow):
         if self.fc is not None:
             self.addNodeWidgetsFromFlowchart(fc)
 
+        
         # start monitor
         if monitorInterval is not None:
             self.setMonitorInterval(monitorInterval)
@@ -129,6 +132,7 @@ class AutoPlotMainWindow(PlotWindow):
         tstamp = time.strftime("%Y-%m-%d %H:%M:%S")
         self.status.showMessage(f"loaded: {tstamp}")
 
+
     @QtCore.pyqtSlot()
     def refreshData(self):
         """
@@ -136,10 +140,12 @@ class AutoPlotMainWindow(PlotWindow):
         """
         self.loaderNode.update()
         self.showTime()
-
+      
         if not self._initialized and self.loaderNode.nLoadedRecords > 0:
             self.setDefaults()
             self._initialized = True
+            
+
 
     @QtCore.pyqtSlot(int)
     def setMonitorInterval(self, val):
@@ -165,6 +171,7 @@ class AutoPlotMainWindow(PlotWindow):
         """
         set some defaults (for convenience).
         """
+
         data = self.loaderNode.outputValues()['dataOut']
         selected = data.dependents()
         if len(selected) > 0:
@@ -208,9 +215,18 @@ class QCAutoPlotMainWindow(AutoPlotMainWindow):
 
         if pathAndId is not None:
             self.loaderNode.pathAndId = pathAndId
-
+        
+        #add qcodes specific snapshot widget
+        d = QtGui.QDockWidget('snapshot', self)
+        self.snapshotWidget = SnapshotWidget()
+        d.setWidget(self.snapshotWidget)
+        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, d)
+        
         if self.loaderNode.nLoadedRecords > 0:
             self.setDefaults()
+            #also setup the snapshot here since the loader node is now initialized 
+            logger().debug('loaded snapshot')
+            self.snapshotWidget.loadSnapshot(self.loaderNode.dataSnapshot)
             self._initialized = True
 
 
@@ -262,3 +278,5 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
     win.setMonitorInterval(2)
 
     return fc, win
+
+

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -12,7 +12,7 @@ from pyqtgraph.Qt import QtGui, QtCore
 from .. import log as plottrlog
 from ..data.qcodes_dataset import (get_runs_from_db_as_dataframe,
                                    get_ds_structure, load_dataset_from)
-from plottr.gui.widgets import MonitorIntervalInput, FormLayoutWrapper
+from plottr.gui.widgets import MonitorIntervalInput, FormLayoutWrapper, dictToTreeWidgetItems
 
 from .autoplot import autoplotQcodesDataset
 
@@ -27,18 +27,6 @@ def logger():
 
 
 ### Database inspector tool
-
-def dictToTreeWidgetItems(d):
-    items = []
-    for k, v in d.items():
-        if not isinstance(v, dict):
-            item = QtGui.QTreeWidgetItem([str(k), str(v)])
-        else:
-            item = QtGui.QTreeWidgetItem([k, ''])
-            for child in dictToTreeWidgetItems(v):
-                item.addChild(child)
-        items.append(item)
-    return items
 
 class DateList(QtGui.QListWidget):
 

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -240,6 +240,9 @@ GUID: {}
 DB-File [ID]: {} [{}]""".format(ds.run_timestamp(), ds.completed_timestamp(),
                                 guid, path, runId)
 
+                #now also load the snapshot and save in the object so we can use it later in the snapshot widget
+                self.dataSnapshot = ds.snapshot
+
                 data = ds_to_datadict(ds)
                 data.add_meta('title', title)
                 data.add_meta('info', info)

--- a/plottr/gui/widgets.py
+++ b/plottr/gui/widgets.py
@@ -131,3 +131,41 @@ class PlotWindow(QtGui.QMainWindow):
             }
             """
         )
+
+
+class SnapshotWidget(QtGui.QTreeWidget):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setHeaderLabels(['Key', 'Value'])
+        self.setColumnCount(2)
+
+    
+    def loadSnapshot(self, snapshotDict : dict):
+        """
+        Loads a qcodes DataSet snapshot in the tree view
+        """
+        self.clear()
+        items = dictToTreeWidgetItems(snapshotDict)
+        for item in items:
+            self.addTopLevelItem(item)
+            item.setExpanded(True)
+
+        #self.expandAll()
+        for i in range(2):
+            self.resizeColumnToContents(i)
+
+
+
+def dictToTreeWidgetItems(d):
+    items = []
+    for k, v in d.items():
+        if not isinstance(v, dict):
+            item = QtGui.QTreeWidgetItem([str(k), str(v)])
+        else:
+            item = QtGui.QTreeWidgetItem([k, ''])
+            for child in dictToTreeWidgetItems(v):
+                item.addChild(child)
+        items.append(item)
+    return items


### PR DESCRIPTION
Wanted to have this feature and saw it was on the list: #20. I Tried to use as much existing code as possible. 

Still quite rudimentary (litterally shows the snapshot tree) but does the job:
![image](https://user-images.githubusercontent.com/8937555/71785253-b948aa80-2ffd-11ea-844d-09ea6d70890e.png)

Can also be undocked like the other widgets so you get a better view
![image](https://user-images.githubusercontent.com/8937555/71785263-eac17600-2ffd-11ea-8a49-6847eab1316a.png)

Displaced the dictToTreeWidgetItems function since i thought it should be in the widget section instead of in the inspectr.py 

Let me know what you think!