### PR TITLE
Fix loadSnapshot to accept None type snapshotDict

### DIFF
--- a/plottr/gui/widgets.py
+++ b/plottr/gui/widgets.py
@@ -4,7 +4,7 @@ widgets.py
 Common GUI widgets that are re-used across plottr.
 """
 
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Optional
 
 from plottr import QtGui, QtCore, Flowchart
 from plottr.node import Node
@@ -141,12 +141,15 @@ class SnapshotWidget(QtGui.QTreeWidget):
         self.setHeaderLabels(['Key', 'Value'])
         self.setColumnCount(2)
 
-    
-    def loadSnapshot(self, snapshotDict : dict):
+    def loadSnapshot(self, snapshotDict : Optional[dict]):
         """
         Loads a qcodes DataSet snapshot in the tree view
         """
         self.clear()
+
+        if snapshotDict is None:
+            return
+
         items = dictToTreeWidgetItems(snapshotDict)
         for item in items:
             self.addTopLevelItem(item)


### PR DESCRIPTION
Fixes #81 

As the issue reports that plottr was crashing in snapshot value was none. This PR fixes the issue.

If snapshot is **NOT NONE**

![image](https://user-images.githubusercontent.com/18750964/74669553-a8b45400-51a7-11ea-89a0-32a107bb75c1.png)

----------------------------------------------------------------------------------------------------------
If snapshot is **None**. The plottr does not not crash and the snapshot values are empty as expected.

![image](https://user-images.githubusercontent.com/18750964/74669666-f466fd80-51a7-11ea-980a-c4e36bb93184.png)
