### PR TITLE
Fix a crash when incompatible data sets are loaded

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -147,14 +147,14 @@ class AutoPlotMainWindow(PlotWindow):
         self.setStatusBar(self.status)
 
         # menu bar
-        menu = self.menuBar()
-        fileMenu = menu.addMenu('&Data')
+        self.menu = self.menuBar()
+        self.fileMenu = self.menu.addMenu('&Data')
 
         if self.loaderNode is not None:
             refreshAction = QtGui.QAction('&Refresh', self)
             refreshAction.setShortcut('R')
             refreshAction.triggered.connect(self.refreshData)
-            fileMenu.addAction(refreshAction)
+            self.fileMenu.addAction(refreshAction)
 
         # add monitor if needed
         if monitor:

--- a/plottr/node/data_selector.py
+++ b/plottr/node/data_selector.py
@@ -6,7 +6,7 @@ A node and widget for subselecting from a dataset.
 from typing import List, Tuple, Dict, Any
 
 from .node import Node, NodeWidget, updateOption
-from ..data.datadict import DataDictBase
+from ..data.datadict import DataDictBase, DataDict
 from ..gui.data_display import DataSelectionWidget
 from plottr.icons import dataColumnsIcon
 from ..utils import num
@@ -158,6 +158,14 @@ class DataSelector(Node):
         data = self._reduceData(data)
         if data is None:
             return None
+
+        # it is possible at this stage that we have data in DataDictBase format
+        # which we cannot process further down the line.
+        # But after extraction of compatible date we can now convert.
+        if isinstance(data, DataDictBase):
+            data = DataDict(**data)
+            if not data.validate():
+                return None
 
         return dict(dataOut=data)
 

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -95,9 +95,10 @@ class ShapeSpecificationWidget(QtGui.QWidget):
             self._axes = axes
 
             for i in range(self.layout.rowCount() - 1):
-                self.layout.removeRow(0)
                 self._widgets[i]['name'].deleteLater()
                 self._widgets[i]['shape'].deleteLater()
+                self.layout.removeRow(0)
+
             self._widgets = {}
 
             for i, ax in enumerate(axes):


### PR DESCRIPTION
Issue was that we propagated data in a type that wasn't supported by nodes downstream.