### PR TITLE
add guid to columnlist

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -120,7 +120,7 @@ class SortableTreeWidgetItem(QtGui.QTreeWidgetItem):
 class RunList(QtGui.QTreeWidget):
     """Shows the list of runs for a given date selection."""
 
-    cols = ['Run ID', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records']
+    cols = ['Run ID', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records', 'GUID']
 
     runSelected = QtCore.pyqtSignal(int)
     runActivated = QtCore.pyqtSignal(int)
@@ -142,6 +142,7 @@ class RunList(QtGui.QTreeWidget):
         lst.append(vals.get('started date', '') + ' ' + vals.get('started time', ''))
         lst.append(vals.get('completed date', '') + ' ' + vals.get('completed time', ''))
         lst.append(str(vals.get('records', '')))
+        lst.append(vals.get('guid', ''))
 
         item = SortableTreeWidgetItem(lst)
         self.addTopLevelItem(item)

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -105,6 +105,7 @@ def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> Dict[str, str]:
         ret['structure'] = get_ds_structure(ds)
 
     ret['records'] = ds.number_of_results
+    ret['guid'] = ds.guid
 
     return ret
 

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -170,7 +170,8 @@ def test_get_ds_info(experiment):
         'completed time': completed_ts[11:],
         'started date': started_ts[:10],
         'started time': started_ts[11:],
-        'records': 0
+        'records': 0,
+        'guid': 'aaaaaaaa-0d00-0000-0000-000000000000'
     }
 
     ds_info = get_ds_info(dataset, get_structure=False)


### PR DESCRIPTION
For comparing measurements not just by run-id, the GUID is added to the column list in the main window, so users can identify/search measurement by the guid as well.

Modifications:

- adds guid to column names and column list
- looks up guid from dataset
- adds a guid to test dataset
