### PR TITLE
remove pathlib from deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pathlib>=1.0.0
 matplotlib>=3.0.0
 numpy>=1.12.0
 pyqtgraph>=0.10.0


### PR DESCRIPTION
this is a now unsupported backport of code that is part of the standard library (since 3.4) 

compare https://pypi.org/project/pathlib/ to https://docs.python.org/3/library/pathlib.html