### PR TITLE
Add entry points for Inspectr and autoplot

### DIFF
--- a/apps/autoplot_ddh5.py
+++ b/apps/autoplot_ddh5.py
@@ -1,25 +1,4 @@
-import sys
-import argparse
-
-from plottr import QtGui
-from plottr.apps.autoplot import autoplotDDH5
-
-
-def main(f, g):
-    app = QtGui.QApplication([])
-    fc, win = autoplotDDH5(f, g)
-
-    return app.exec_()
-
+from plottr.apps.autoplot import script
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='plottr autoplot .dd.h5 files.'
-    )
-    parser.add_argument('--filepath', help='path to .dd.h5 file',
-                        default='')
-    parser.add_argument('--groupname', help='group in the hdf5 file',
-                        default='data')
-    args = parser.parse_args()
-
-    main(args.filepath, args.groupname)
+    script()

--- a/apps/inspectr.py
+++ b/apps/inspectr.py
@@ -1,28 +1,4 @@
-import sys
-import argparse
-
-from pyqtgraph.Qt import QtCore, QtGui
-
-from plottr import log as plottrlog
 from plottr.apps import inspectr
 
-
-def main(dbPath):
-    app = QtGui.QApplication([])
-    plottrlog.enableStreamHandler(True)
-
-    win = inspectr.inspectr(dbPath=dbPath)
-    win.show()
-
-    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
-        QtGui.QApplication.instance().exec_()
-
-
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='inspectr -- sifting through qcodes data.')
-    parser.add_argument('--dbpath', help='path to qcodes .db file',
-                        default=None)
-
-    args = parser.parse_args()
-
-    main(args.dbpath)
+    inspectr.script()

--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -5,6 +5,7 @@ plottr/apps/autoplot.py : tools for simple automatic plotting.
 import logging
 import os
 import time
+import argparse
 from typing import Union, Tuple
 
 from .. import QtGui, QtCore, Flowchart, Signal, Slot
@@ -327,3 +328,23 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
     win.setMonitorInterval(2)
 
     return fc, win
+
+
+def main(f, g):
+    app = QtGui.QApplication([])
+    fc, win = autoplotDDH5(f, g)
+
+    return app.exec_()
+
+
+def script():
+    parser = argparse.ArgumentParser(
+        description='plottr autoplot .dd.h5 files.'
+    )
+    parser.add_argument('--filepath', help='path to .dd.h5 file',
+                        default='')
+    parser.add_argument('--groupname', help='group in the hdf5 file',
+                        default='data')
+    args = parser.parse_args()
+
+    main(args.filepath, args.groupname)

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -14,6 +14,8 @@ data. it relies on the public qcodes API to get its information.
 
 import os
 import time
+import sys
+import argparse
 
 from pyqtgraph.Qt import QtGui, QtCore
 
@@ -478,3 +480,22 @@ class QCodesDBInspector(QtGui.QMainWindow):
 def inspectr(dbPath: str = None):
     win = QCodesDBInspector(dbPath=dbPath)
     return win
+
+
+def main(dbPath):
+    app = QtGui.QApplication([])
+    plottrlog.enableStreamHandler(True)
+
+    win = inspectr(dbPath=dbPath)
+    win.show()
+
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
+
+def script():
+    parser = argparse.ArgumentParser(description='inspectr -- sifting through qcodes data.')
+    parser.add_argument('--dbpath', help='path to qcodes .db file',
+                        default=None)
+    args = parser.parse_args()
+    main(args.dbpath)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "console_scripts": [
             "plottr-monitr = plottr.apps.monitr:script",
             "plottr-inspectr = plottr.apps.inspectr:script",
+            "plottr-autoplot-ddh5 = plottr.apps.autoplot:script",
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     entry_points={
         "console_scripts": [
             "plottr-monitr = plottr.apps.monitr:script",
+            "plottr-inspectr = plottr.apps.inspectr:script",
         ],
     }
 )


### PR DESCRIPTION
This way both tools can be lauched from the commandline in the same way as monitr directly from a pip installed version of plottr without needing the app folder to be downloaded. 

The old app folder is retanind for backwards compatibility