### PR TITLE
Prepare for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 doc/_build
 doc/make.bat
 doc/Makefile
+build/
+dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2020 Wolfgang Pfaff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,17 @@ setup(
         'lmfit',
         'h5py>=2.10.0',
     ],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Topic :: Scientific/Engineering'
+    ],
+    python_requires='>=3.6',
     entry_points={
         "console_scripts": [
             "plottr-monitr = plottr.apps.monitr:script",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     author='Wolfgang Pfaff',
     author_email='wolfgangpfff@gmail.com',
     url='https://github.com/toolsforexperiments/plottr',
-    packages=find_packages(),
+    packages=find_packages(include=("plottr*",)),
+    package_data={'plottr': ['resource/gfx/*']},
     install_requires=[
         'pandas>=0.22',
         'xarray',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='plottr',
     version='0.1.0',
     description='A tool for live plotting and processing data',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Wolfgang Pfaff',
     author_email='wolfgangpfff@gmail.com',
     url='https://github.com/toolsforexperiments/plottr',


### PR DESCRIPTION
@wpfff 

This adds a few formalities in preparation for an official release to pypi. 

* A licence file with the MIT licence. As far as I can see from the code that is the intended licence?
* Embed the readme as long description as recommended https://packaging.python.org/tutorials/packaging-projects/
* Add classifiers and mark the package as only supporting python 3.6 and up 
* Tweek find_package and data such that the correct files are included in the installed package