### PR TITLE
Import QtWidgets from more canonical locations

### DIFF
--- a/plottr/__init__.py
+++ b/plottr/__init__.py
@@ -1,7 +1,6 @@
 import os
 
-from pyqtgraph import QtCore, QtGui
-QtWidgets = QtGui
+from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
 Signal = QtCore.pyqtSignal
 Slot = QtCore.pyqtSlot
 

--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -8,7 +8,7 @@ import time
 import argparse
 from typing import Union, Tuple, Optional, Type, List
 
-from .. import QtGui, QtCore, Flowchart, Signal, Slot
+from .. import QtCore, Flowchart, Signal, Slot, QtWidgets
 from .. import log as plottrlog
 from ..data.datadict import DataDictBase
 from ..data.datadict_storage import DDH5Loader
@@ -70,7 +70,7 @@ def autoplot(inputData: Union[None, DataDictBase] = None) \
     return fc, win
 
 
-class UpdateToolBar(QtGui.QToolBar):
+class UpdateToolBar(QtWidgets.QToolBar):
     """
     A very simple toolbar to enable monitoring or triggering based on a timer.
     Contains a timer whose interval can be set.
@@ -127,7 +127,7 @@ class AutoPlotMainWindow(PlotWindow):
     windowClosed = Signal()
 
     def __init__(self, fc: Flowchart,
-                 parent: Union[QtGui.QWidget, None] = None,
+                 parent: Union[QtWidgets.QWidget, None] = None,
                  monitor: bool = False,
                  monitorInterval: Union[int, None] = None,
                  loaderName: str = None,
@@ -149,7 +149,7 @@ class AutoPlotMainWindow(PlotWindow):
         self.setWindowTitle(windowTitle)
 
         # status bar
-        self.status = QtGui.QStatusBar()
+        self.status = QtWidgets.QStatusBar()
         self.setStatusBar(self.status)
 
         # menu bar
@@ -157,7 +157,7 @@ class AutoPlotMainWindow(PlotWindow):
         self.fileMenu = self.menu.addMenu('&Data')
 
         if self.loaderNode is not None:
-            refreshAction = QtGui.QAction('&Refresh', self)
+            refreshAction = QtWidgets.QAction('&Refresh', self)
             refreshAction.setShortcut('R')
             refreshAction.triggered.connect(self.refreshData)
             self.fileMenu.addAction(refreshAction)
@@ -251,7 +251,7 @@ class QCAutoPlotMainWindow(AutoPlotMainWindow):
     """
 
     def __init__(self, fc: Flowchart,
-                 parent: Union[QtGui.QWidget, None] = None,
+                 parent: Union[QtWidgets.QWidget, None] = None,
                  pathAndId: Union[Tuple[str, int], None] = None, **kw):
 
         super().__init__(fc, parent, **kw)
@@ -332,7 +332,7 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
 
 
 def main(f, g):
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     fc, win = autoplotDDH5(f, g)
 
     return app.exec_()

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -17,7 +17,7 @@ import time
 import sys
 import argparse
 
-from pyqtgraph.Qt import QtGui, QtCore
+from plottr import QtGui, QtCore, QtWidgets
 
 from .. import log as plottrlog
 from ..data.qcodes_dataset import (get_runs_from_db_as_dataframe,
@@ -38,7 +38,7 @@ def logger():
 
 ### Database inspector tool
 
-class DateList(QtGui.QListWidget):
+class DateList(QtWidgets.QListWidget):
     """Displays a list of dates for which there are runs in the database."""
 
     datesSelected = QtCore.pyqtSignal(list)
@@ -50,7 +50,7 @@ class DateList(QtGui.QListWidget):
         self.setAcceptDrops(True)
         self.setDefaultDropAction(QtCore.Qt.CopyAction)
 
-        self.setSelectionMode(QtGui.QListView.ExtendedSelection)
+        self.setSelectionMode(QtWidgets.QListView.ExtendedSelection)
         self.itemSelectionChanged.connect(self.sendSelectedDates)
 
     @QtCore.pyqtSlot(list)
@@ -101,7 +101,7 @@ class DateList(QtGui.QListWidget):
     ])
 
 
-class SortableTreeWidgetItem(QtGui.QTreeWidgetItem):
+class SortableTreeWidgetItem(QtWidgets.QTreeWidgetItem):
     """
     QTreeWidgetItem with an overridden comparator that sorts numerical values
     as numbers instead of sorting them alphabetically.
@@ -119,7 +119,7 @@ class SortableTreeWidgetItem(QtGui.QTreeWidgetItem):
             return text1 < text2
 
 
-class RunList(QtGui.QTreeWidget):
+class RunList(QtWidgets.QTreeWidget):
     """Shows the list of runs for a given date selection."""
 
     cols = ['Run ID', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records', 'GUID']
@@ -172,13 +172,13 @@ class RunList(QtGui.QTreeWidget):
         runId = int(selection[0].text(0))
         self.runSelected.emit(runId)
 
-    @QtCore.pyqtSlot(QtGui.QTreeWidgetItem, int)
+    @QtCore.pyqtSlot(QtWidgets.QTreeWidgetItem, int)
     def activateRun(self, item, column):
         runId = int(item.text(0))
         self.runActivated.emit(runId)
 
 
-class RunInfo(QtGui.QTreeWidget):
+class RunInfo(QtWidgets.QTreeWidget):
     """widget that shows some more details on a selected run.
 
     When sending information in form of a dictionary, it will create
@@ -223,7 +223,7 @@ class LoadDBProcess(QtCore.QObject):
         self.dbdfLoaded.emit(dbdf)
 
 
-class QCodesDBInspector(QtGui.QMainWindow):
+class QCodesDBInspector(QtWidgets.QMainWindow):
     """
     Main window of the inspectr tool.
     """
@@ -261,12 +261,12 @@ class QCodesDBInspector(QtGui.QMainWindow):
         self.runList = RunList()
         self.runInfo = RunInfo()
 
-        rightSplitter = QtGui.QSplitter(QtCore.Qt.Vertical)
+        rightSplitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
         rightSplitter.addWidget(self.runList)
         rightSplitter.addWidget(self.runInfo)
         rightSplitter.setSizes([400, 200])
 
-        splitter = QtGui.QSplitter()
+        splitter = QtWidgets.QSplitter()
         splitter.addWidget(self.dateList)
         splitter.addWidget(rightSplitter)
         splitter.setSizes([100, 500])
@@ -274,7 +274,7 @@ class QCodesDBInspector(QtGui.QMainWindow):
         self.setCentralWidget(splitter)
 
         # status bar
-        self.status = QtGui.QStatusBar()
+        self.status = QtWidgets.QStatusBar()
         self.setStatusBar(self.status)
 
         # toolbar
@@ -290,7 +290,7 @@ class QCodesDBInspector(QtGui.QMainWindow):
 
         # toolbar item: auto-launch plotting
         self.autoLaunchPlots = FormLayoutWrapper([
-            ('Auto-plot new', QtGui.QCheckBox())
+            ('Auto-plot new', QtWidgets.QCheckBox())
         ])
         tt = "If checked, and automatic refresh is running, "
         tt += " launch plotting window for new datasets automatically."
@@ -302,13 +302,13 @@ class QCodesDBInspector(QtGui.QMainWindow):
         fileMenu = menu.addMenu('&File')
 
         # action: load db file
-        loadAction = QtGui.QAction('&Load', self)
+        loadAction = QtWidgets.QAction('&Load', self)
         loadAction.setShortcut('Ctrl+L')
         loadAction.triggered.connect(self.loadDB)
         fileMenu.addAction(loadAction)
 
         # action: updates from the db file
-        refreshAction = QtGui.QAction('&Refresh', self)
+        refreshAction = QtWidgets.QAction('&Refresh', self)
         refreshAction.setShortcut('R')
         refreshAction.triggered.connect(self.refreshDB)
         fileMenu.addAction(refreshAction)
@@ -373,7 +373,7 @@ class QCodesDBInspector(QtGui.QMainWindow):
         else:
             curdir = os.getcwd()
 
-        path, _fltr = QtGui.QFileDialog.getOpenFileName(
+        path, _fltr = QtWidgets.QFileDialog.getOpenFileName(
             self,
             'Open qcodes .db file',
             curdir,
@@ -483,14 +483,14 @@ def inspectr(dbPath: str = None):
 
 
 def main(dbPath):
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     plottrlog.enableStreamHandler(True)
 
     win = inspectr(dbPath=dbPath)
     win.show()
 
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
-        QtGui.QApplication.instance().exec_()
+        QtWidgets.QApplication.instance().exec_()
 
 
 def script():

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -22,7 +22,7 @@ from typing import Any, Union, Optional, List
 import numpy as np
 import h5py
 
-from plottr import QtGui, Signal, Slot
+from plottr import QtGui, Signal, Slot, QtWidgets
 
 from ..node import (
     Node, NodeWidget, updateOption, updateGuiFromNode,
@@ -387,9 +387,9 @@ class DDH5LoaderWidget(NodeWidget):
     def __init__(self, node: Node = None):
         super().__init__(node=node)
 
-        self.fileinput = QtGui.QLineEdit()
-        self.groupinput = QtGui.QLineEdit('data')
-        self.reload = QtGui.QPushButton('Reload')
+        self.fileinput = QtWidgets.QLineEdit()
+        self.groupinput = QtWidgets.QLineEdit('data')
+        self.reload = QtWidgets.QPushButton('Reload')
 
         self.optSetters = {
             'filepath': self.fileinput.setText,
@@ -400,11 +400,11 @@ class DDH5LoaderWidget(NodeWidget):
             'groupname': self.groupinput.text,
         }
 
-        flayout = QtGui.QFormLayout()
+        flayout = QtWidgets.QFormLayout()
         flayout.addRow('File path:', self.fileinput)
         flayout.addRow('Group:', self.groupinput)
 
-        vlayout = QtGui.QVBoxLayout()
+        vlayout = QtWidgets.QVBoxLayout()
         vlayout.addLayout(flayout)
         vlayout.addWidget(self.reload)
 

--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -5,17 +5,17 @@ UI elements for inspecting data structure and content.
 
 from typing import Union, List, Tuple, Dict
 
-from .. import QtGui, QtCore
+from .. import QtCore, QtWidgets
 from ..data.datadict import DataDictBase
 
 
-class DataSelectionWidget(QtGui.QTreeWidget):
+class DataSelectionWidget(QtWidgets.QTreeWidget):
     """A simple tree widget to show data fields and dependencies."""
 
     #: signal (List[str]) that is emitted when the selection is modified.
     dataSelectionMade = QtCore.pyqtSignal(list)
 
-    def __init__(self, parent: QtGui.QWidget = None, readonly: bool = False):
+    def __init__(self, parent: QtWidgets.QWidget = None, readonly: bool = False):
         super().__init__(parent)
 
         self.setColumnCount(3)
@@ -42,7 +42,7 @@ class DataSelectionWidget(QtGui.QTreeWidget):
             deps += axlabel
         deps += ")"
 
-        return QtGui.QTreeWidgetItem([
+        return QtWidgets.QTreeWidgetItem([
             label, deps, str(shape)
         ])
 

--- a/plottr/gui/tools.py
+++ b/plottr/gui/tools.py
@@ -3,17 +3,17 @@
 helpers and tools for creating GUI elements.
 """
 
-from .. import QtGui
+from .. import QtWidgets
 
 __author__ = 'Wolfgang Pfaff'
 __license__ = 'MIT'
 
 
-def widgetDialog(widget: QtGui.QWidget, title: str = '',
-                 show: bool = True) -> QtGui.QDialog:
-    win = QtGui.QDialog()
+def widgetDialog(widget: QtWidgets.QWidget, title: str = '',
+                 show: bool = True) -> QtWidgets.QDialog:
+    win = QtWidgets.QDialog()
     win.setWindowTitle('plottr ' + title)
-    layout = QtGui.QVBoxLayout()
+    layout = QtWidgets.QVBoxLayout()
     layout.addWidget(widget)
     win.setLayout(layout)
     if show:
@@ -26,9 +26,9 @@ def dictToTreeWidgetItems(d):
     items = []
     for k, v in d.items():
         if not isinstance(v, dict):
-            item = QtGui.QTreeWidgetItem([str(k), str(v)])
+            item = QtWidgets.QTreeWidgetItem([str(k), str(v)])
         else:
-            item = QtGui.QTreeWidgetItem([k, ''])
+            item = QtWidgets.QTreeWidgetItem([k, ''])
             for child in dictToTreeWidgetItems(v):
                 item.addChild(child)
         items.append(item)

--- a/plottr/gui/widgets.py
+++ b/plottr/gui/widgets.py
@@ -7,7 +7,7 @@ Common GUI widgets that are re-used across plottr.
 from typing import Union, List, Tuple, Optional, Type, Sequence, Dict
 
 from .tools import dictToTreeWidgetItems
-from plottr import QtGui, QtCore, Flowchart
+from plottr import QtCore, Flowchart, QtWidgets
 from plottr.node import Node, linearFlowchart
 from ..plot import PlotNode, PlotWidgetContainer, MPLAutoPlot
 
@@ -15,7 +15,7 @@ __author__ = 'Wolfgang Pfaff'
 __license__ = 'MIT'
 
 
-class FormLayoutWrapper(QtGui.QWidget):
+class FormLayoutWrapper(QtWidgets.QWidget):
     """
     Simple wrapper widget for forms.
     Expects a list of tuples of the form (label, widget),
@@ -23,13 +23,13 @@ class FormLayoutWrapper(QtGui.QWidget):
     Labels have to be unique.
     """
 
-    def __init__(self, elements: List[Tuple[str, QtGui.QWidget]],
-                 parent: Union[None, QtGui.QWidget] = None):
+    def __init__(self, elements: List[Tuple[str, QtWidgets.QWidget]],
+                 parent: Union[None, QtWidgets.QWidget] = None):
         super().__init__(parent)
 
         self.elements = {}
 
-        layout = QtGui.QFormLayout()
+        layout = QtWidgets.QFormLayout()
         for lbl, widget in elements:
             self.elements[lbl] = widget
             layout.addRow(lbl, widget)
@@ -37,7 +37,7 @@ class FormLayoutWrapper(QtGui.QWidget):
         self.setLayout(layout)
 
 
-class MonitorIntervalInput(QtGui.QWidget):
+class MonitorIntervalInput(QtWidgets.QWidget):
     """
     Simple form-like widget for entering a monitor/refresh interval.
     Only has a label and a spin-box as input.
@@ -51,8 +51,8 @@ class MonitorIntervalInput(QtGui.QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.spin = QtGui.QSpinBox()
-        layout = QtGui.QFormLayout()
+        self.spin = QtWidgets.QSpinBox()
+        layout = QtWidgets.QFormLayout()
         layout.addRow('Refresh interval (s)', self.spin)
         self.setLayout(layout)
 
@@ -63,7 +63,7 @@ class MonitorIntervalInput(QtGui.QWidget):
         self.intervalChanged.emit(val)
 
 
-class PlotWindow(QtGui.QMainWindow):
+class PlotWindow(QtWidgets.QMainWindow):
     """
     Simple MainWindow class for embedding flowcharts and plots.
 
@@ -80,10 +80,10 @@ class PlotWindow(QtGui.QMainWindow):
         self.setCentralWidget(self.plot)
         self.plotWidget: Optional[MPLAutoPlot] = None
 
-        self.nodeToolBar = QtGui.QToolBar('Node control', self)
+        self.nodeToolBar = QtWidgets.QToolBar('Node control', self)
         self.addToolBar(self.nodeToolBar)
 
-        self.nodeWidgets: Dict[str, QtGui.QDockWidget] = {}
+        self.nodeWidgets: Dict[str, QtWidgets.QDockWidget] = {}
         if fc is not None:
             self.addNodeWidgetsFromFlowchart(fc, **kw)
 
@@ -117,12 +117,12 @@ class PlotWindow(QtGui.QMainWindow):
               an icon to use for the toolbar
         """
 
-        if node.useUi and node.uiClass is not None:
+        if node.ui is not None and node.useUi and node.uiClass is not None:
             dockArea = kwargs.get('dockArea', node.ui.preferredDockWidgetArea)
             visible = kwargs.get('visible', node.uiVisibleByDefault)
             icon = kwargs.get('icon', node.ui.icon)
 
-            d = QtGui.QDockWidget(node.name(), self)
+            d = QtWidgets.QDockWidget(node.name(), self)
             d.setWidget(node.ui)
             self.nodeWidgets[node.name()] = d
             self.addDockWidget(dockArea, d)
@@ -183,7 +183,7 @@ def makeFlowchartWithPlotWindow(nodes: List[Tuple[str, Type[Node]]], **kwargs) \
     return win, fc
 
 
-class SnapshotWidget(QtGui.QTreeWidget):
+class SnapshotWidget(QtWidgets.QTreeWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/plottr/node/autonode.py
+++ b/plottr/node/autonode.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-from .. import QtGui
+from .. import QtGui, QtWidgets
 from .node import Node, NodeWidget, updateOption
 
 
@@ -14,7 +14,7 @@ def connectIntegerSpinbox(
         specs: Dict[str, Any],
         confirm: bool):
 
-    widget = QtGui.QSpinBox()
+    widget = QtWidgets.QSpinBox()
     widget.setValue(specs.get('initialValue', 1))
     if not confirm:
         widget.valueChanged.connect(lambda x: gui.signalOption(optionName))
@@ -30,7 +30,7 @@ def connectFloatSpinbox(
         specs: Dict[str, Any],
         confirm: bool):
 
-    widget = QtGui.QDoubleSpinBox()
+    widget = QtWidgets.QDoubleSpinBox()
     widget.setValue(specs.get('initialValue', 1))
     if not confirm:
         widget.valueChanged.connect(lambda x: gui.signalOption(optionName))
@@ -50,7 +50,7 @@ class AutoNodeGui(AutoNodeGuiTemplate):
 
     def __init__(self, parent=None, node=None):
         super().__init__(parent)
-        self.layout = QtGui.QFormLayout()
+        self.layout = QtWidgets.QFormLayout()
         self.setLayout(self.layout)
 
     def addOption(self, name: str, specs: Dict[str, Any], confirm: bool):
@@ -63,7 +63,7 @@ class AutoNodeGui(AutoNodeGuiTemplate):
         self.layout.addRow(name, widget)
 
     def addConfirm(self):
-        widget = QtGui.QPushButton('Confirm')
+        widget = QtWidgets.QPushButton('Confirm')
         widget.pressed.connect(self.signalAllOptions)
         self.layout.addRow('', widget)
 

--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .node import Node, updateOption, NodeWidget
 from ..data.datadict import MeshgridDataDict, DataDict, DataDictBase
-from .. import QtGui, QtCore
+from .. import QtGui, QtCore, QtWidgets
 from plottr.icons import xySelectIcon
 
 __author__ = 'Wolfgang Pfaff'
@@ -61,7 +61,7 @@ reductionFunc = {
     ReductionMethod.average: np.mean,
 }
 
-class DimensionAssignmentWidget(QtGui.QTreeWidget):
+class DimensionAssignmentWidget(QtWidgets.QTreeWidget):
     """
     A Widget that allows to assign options ('roles') to dimensions of a
     dataset.
@@ -151,10 +151,10 @@ class DimensionAssignmentWidget(QtGui.QTreeWidget):
 
         :param name: name of the dimension.
         """
-        item = QtGui.QTreeWidgetItem([name, '', '', ''])
+        item = QtWidgets.QTreeWidgetItem([name, '', '', ''])
         self.addTopLevelItem(item)
 
-        combo = QtGui.QComboBox()
+        combo = QtWidgets.QComboBox()
         for t, opts in self.availableChoices.items():
             if t == self._dataType or issubclass(self._dataType, t):
                 for o in opts:
@@ -304,13 +304,13 @@ class DimensionReductionAssignmentWidget(DimensionAssignmentWidget):
             self._setElementSelectionInfo(dim)
 
     def elementSelectionSlider(self, nvals: int, value: int = 0):
-        w = QtGui.QSlider(0x01)
+        w = QtWidgets.QSlider(0x01)
         w.setMinimum(0)
         w.setMaximum(nvals - 1)
         w.setSingleStep(1)
         w.setPageStep(1)
         w.setTickInterval(max(1, nvals//10))
-        w.setTickPosition(QtGui.QSlider.TicksBelow)
+        w.setTickPosition(QtWidgets.QSlider.TicksBelow)
         w.setValue(value)
         return w
 

--- a/plottr/node/filter/correct_offset.py
+++ b/plottr/node/filter/correct_offset.py
@@ -1,13 +1,13 @@
 from typing import Sequence
 
-from plottr import QtGui, Signal, Slot
+from plottr import Signal, Slot, QtWidgets
 from plottr.node import Node, NodeWidget, updateOption
 from plottr.node.node import updateGuiQuietly, emitGuiUpdate
 from plottr.gui.widgets import FormLayoutWrapper
 from plottr.data.datadict import DataDictBase, MeshgridDataDict
 
 
-class DimensionCombo(QtGui.QComboBox):
+class DimensionCombo(QtWidgets.QComboBox):
     dimensionSelected = Signal(str)
 
     def __init__(self, parent=None, dimensionType='axes'):

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -8,7 +8,7 @@ from enum import Enum, unique
 
 from typing import Tuple, Dict, Any, List, Union
 
-from plottr import QtGui, Signal, Slot
+from plottr import QtGui, Signal, Slot, QtWidgets
 from .node import Node, NodeWidget, updateOption, updateGuiFromNode
 from ..data import datadict as dd
 from ..data.datadict import DataDict, MeshgridDataDict, DataDictBase
@@ -36,7 +36,7 @@ class GridOption(Enum):
     specifyShape = 2
 
 
-class ShapeSpecificationWidget(QtGui.QWidget):
+class ShapeSpecificationWidget(QtWidgets.QWidget):
     """A widget that allows the user to specify a grid shape.
 
     Note that this widget in this form knows nothing about any underlying data,
@@ -55,8 +55,8 @@ class ShapeSpecificationWidget(QtGui.QWidget):
         self._widgets = {}
         self._processChanges = True
 
-        self.layout = QtGui.QFormLayout()
-        self.confirm = QtGui.QPushButton('set')
+        self.layout = QtWidgets.QFormLayout()
+        self.confirm = QtWidgets.QPushButton('set')
         self.layout.addRow(self.confirm)
         self.setLayout(self.layout)
 
@@ -67,12 +67,12 @@ class ShapeSpecificationWidget(QtGui.QWidget):
         self.newShapeNotification.emit(self.getShape())
 
     def _addAxis(self, idx, name):
-        nameWidget = QtGui.QComboBox()
+        nameWidget = QtWidgets.QComboBox()
         for j, bx in enumerate(self._axes):
             nameWidget.addItem(bx)
         nameWidget.setCurrentText(name)
 
-        dimLenWidget = QtGui.QSpinBox()
+        dimLenWidget = QtWidgets.QSpinBox()
         dimLenWidget.setMinimum(1)
         dimLenWidget.setMaximum(999999)
         self._widgets[idx] = {
@@ -178,13 +178,13 @@ class GridOptionWidget(QtGui.QWidget):
 
         #  make radio buttons and layout
         self.buttons = {
-            GridOption.noGrid: QtGui.QRadioButton('No grid'),
-            GridOption.guessShape: QtGui.QRadioButton('Guess shape'),
-            GridOption.specifyShape: QtGui.QRadioButton('Specify shape'),
+            GridOption.noGrid: QtWidgets.QRadioButton('No grid'),
+            GridOption.guessShape: QtWidgets.QRadioButton('Guess shape'),
+            GridOption.specifyShape: QtWidgets.QRadioButton('Specify shape'),
         }
 
-        btnLayout = QtGui.QVBoxLayout()
-        self.btnGroup = QtGui.QButtonGroup(self)
+        btnLayout = QtWidgets.QVBoxLayout()
+        self.btnGroup = QtWidgets.QButtonGroup(self)
 
         for opt in GridOption:
             btn = self.buttons[opt]
@@ -193,13 +193,13 @@ class GridOptionWidget(QtGui.QWidget):
 
         # make shape spec widget
         self.shapeSpec = ShapeSpecificationWidget()
-        shapeLayout = QtGui.QVBoxLayout()
+        shapeLayout = QtWidgets.QVBoxLayout()
         shapeLayout.addWidget(self.shapeSpec)
-        shapeBox = QtGui.QGroupBox()
+        shapeBox = QtWidgets.QGroupBox()
         shapeBox.setLayout(shapeLayout)
 
         # Widget layout
-        layout = QtGui.QVBoxLayout()
+        layout = QtWidgets.QVBoxLayout()
         layout.addLayout(btnLayout)
         layout.addWidget(shapeBox)
         layout.addStretch()
@@ -249,8 +249,8 @@ class GridOptionWidget(QtGui.QWidget):
 
         self._emitUpdate = True
 
-    @Slot(QtGui.QAbstractButton, bool)
-    def gridButtonSelected(self, btn: QtGui.QAbstractButton, checked: bool):
+    @Slot(QtWidgets.QAbstractButton, bool)
+    def gridButtonSelected(self, btn: QtWidgets.QAbstractButton, checked: bool):
         """Process a change in grid option radio box selection.
         Only has an effect when the change was done manually, and is not
         coming from the node.

--- a/plottr/node/node.py
+++ b/plottr/node/node.py
@@ -10,7 +10,7 @@ from functools import wraps
 from typing import Any, Union, Tuple, Dict, Optional, Type, List
 
 from .. import NodeBase
-from .. import QtGui, QtCore, Signal, Slot
+from .. import QtGui, QtCore, Signal, Slot, QtWidgets
 from ..data.datadict import DataDictBase, MeshgridDataDict
 from .. import log
 
@@ -181,7 +181,7 @@ class Node(NodeBase):
         self.ui.allOptionsToNode.connect(self.setOptions)
         self.optionChangeNotification.connect(self.ui.setOptionsFromNode)
 
-    def ctrlWidget(self) -> Union[QtGui.QWidget, None]:
+    def ctrlWidget(self) -> Union[QtWidgets.QWidget, None]:
         """Returns the node widget, if it exists.
         """
         return self.ui
@@ -310,7 +310,7 @@ class Node(NodeBase):
         return dict(dataOut=dataIn)
 
 
-class NodeWidget(QtGui.QWidget):
+class NodeWidget(QtWidgets.QWidget):
     """
     Base class for Node control widgets.
 
@@ -332,8 +332,8 @@ class NodeWidget(QtGui.QWidget):
     #: signal (args: (object)) all options to the node.
     allOptionsToNode = QtCore.pyqtSignal(object)
 
-    def __init__(self, parent: QtGui.QWidget = None,
-                 embedWidgetClass: Type[QtGui.QWidget] = None,
+    def __init__(self, parent: QtWidgets.QWidget = None,
+                 embedWidgetClass: Type[QtWidgets.QWidget] = None,
                  node: Node = None):
         super().__init__(parent)
 
@@ -343,9 +343,10 @@ class NodeWidget(QtGui.QWidget):
 
         self._emitGuiChange = True
 
-        self.widget: Optional[QtGui.QWidget] = None
+        self.widget: Optional[QtWidgets.QWidget] = None
+
         if embedWidgetClass is not None:
-            layout = QtGui.QVBoxLayout()
+            layout = QtWidgets.QVBoxLayout()
             layout.setContentsMargins(0, 0, 0, 0)
             self.widget = embedWidgetClass()
             layout.addWidget(self.widget)

--- a/plottr/plot/base.py
+++ b/plottr/plot/base.py
@@ -4,7 +4,7 @@ plottr/plot/base.py : Contains the base classes for plotting nodes and widgets.
 
 from typing import Dict, List, Type, Tuple, Optional
 
-from .. import QtGui, Signal, Flowchart
+from .. import Signal, Flowchart, QtWidgets
 from ..data.datadict import DataDictBase
 from ..node import Node, linearFlowchart
 
@@ -52,7 +52,7 @@ class PlotNode(Node):
         return dict(dataOut=dataIn)
 
 
-class PlotWidgetContainer(QtGui.QWidget):
+class PlotWidgetContainer(QtWidgets.QWidget):
     """
     This is the base widget for Plots, derived from `QWidget`.
 
@@ -64,14 +64,14 @@ class PlotWidgetContainer(QtGui.QWidget):
     added to this container.
     """
 
-    def __init__(self, parent: QtGui.QWidget = None):
+    def __init__(self, parent: QtWidgets.QWidget = None):
         """Constructor for :class:`PlotWidgetContainer`. """
         super().__init__(parent=parent)
 
         self.plotWidget: Optional["PlotWidget"] = None
         self.data: Optional[DataDictBase] = None
 
-        self.layout = QtGui.QVBoxLayout(self)
+        self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.setContentsMargins(0, 0, 0, 0)
 
     def setPlotWidget(self, widget: "PlotWidget"):
@@ -107,7 +107,7 @@ class PlotWidgetContainer(QtGui.QWidget):
             self.plotWidget.setData(self.data)
 
 
-class PlotWidget(QtGui.QWidget):
+class PlotWidget(QtWidgets.QWidget):
     """
     Base class for Plot Widgets, this just defines the API. Derived from
     `QWidget`.

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -21,7 +21,7 @@ from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from .base import PlotWidget
-from .. import QtGui, QtCore, Signal, Slot
+from .. import QtGui, QtCore, Signal, Slot, QtWidgets
 from ..utils import num
 from ..utils.num import interp_meshgrid_2d, centers2edges_2d
 from ..data.datadict import DataDictBase, DataDict, MeshgridDataDict
@@ -408,7 +408,7 @@ class MPLPlot(FCanvas):
     It can be used as any QT widget.
     """
 
-    def __init__(self, parent: QtGui.QWidget = None, width: float = 4.0,
+    def __init__(self, parent: QtWidgets.QWidget = None, width: float = 4.0,
                  height: float = 3.0, dpi: int = 150, nrows: int = 1,
                  ncols: int = 1):
         """
@@ -521,7 +521,7 @@ class MPLPlot(FCanvas):
         buf = io.BytesIO()
         self.fig.savefig(buf, dpi=300, facecolor='w', format='png',
                          transparent=True)
-        QtGui.QApplication.clipboard().setImage(
+        QtWidgets.QApplication.clipboard().setImage(
             QtGui.QImage.fromData(buf.getvalue()))
         buf.close()
 
@@ -567,7 +567,7 @@ class _MPLPlotWidget(PlotWidget):
         self.addMplBarOptions()
         self.mplBar.setIconSize(QtCore.QSize(16,16))
 
-        self.layout = QtGui.QVBoxLayout(self)
+        self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.addWidget(self.plot)
         self.layout.addWidget(self.mplBar)
 
@@ -579,10 +579,10 @@ class _MPLPlotWidget(PlotWidget):
             self.plot.setFigureInfo(data.meta_val('info'))
 
     def addMplBarOptions(self):
-        tlCheck = QtGui.QCheckBox('Tight layout')
+        tlCheck = QtWidgets.QCheckBox('Tight layout')
         tlCheck.toggled.connect(self.plot.setTightLayout)
 
-        infoCheck = QtGui.QCheckBox('Info')
+        infoCheck = QtWidgets.QCheckBox('Info')
         infoCheck.toggled.connect(self.plot.setShowInfo)
 
         self.mplBar.addSeparator()
@@ -594,7 +594,7 @@ class _MPLPlotWidget(PlotWidget):
 
 
 # A toolbar for setting options on the MPL autoplot
-class _AutoPlotToolBar(QtGui.QToolBar):
+class _AutoPlotToolBar(QtWidgets.QToolBar):
     """
     A toolbar that allows the user to configure AutoPlot.
 
@@ -609,7 +609,7 @@ class _AutoPlotToolBar(QtGui.QToolBar):
     complexPolarSelected = Signal(bool)
 
 
-    def __init__(self, name: str, parent: QtGui.QWidget = None):
+    def __init__(self, name: str, parent: QtWidgets.QWidget = None):
         """Constructor for :class:`AutoPlotToolBar`"""
 
         super().__init__(name, parent=parent)


### PR DESCRIPTION
Widgets are defined in QtWidgets and not QtGui (that reexports them)

This moves the imports to QtWidgets. 
Doing this fixes many warnings in Pycharm and enables typechecking with https://pypi.org/project/PyQt5-stubs/