### PR TITLE
Improve qt imports

### DIFF
--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -5,7 +5,7 @@ UI elements for inspecting data structure and content.
 
 from typing import Union, List, Tuple, Dict
 
-from .. import QtCore, QtWidgets
+from .. import QtCore, QtWidgets, Signal, Slot
 from ..data.datadict import DataDictBase
 
 
@@ -13,7 +13,7 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
     """A simple tree widget to show data fields and dependencies."""
 
     #: signal (List[str]) that is emitted when the selection is modified.
-    dataSelectionMade = QtCore.pyqtSignal(list)
+    dataSelectionMade = Signal(list)
 
     def __init__(self, parent: QtWidgets.QWidget = None, readonly: bool = False):
         super().__init__(parent)
@@ -46,7 +46,7 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
             label, deps, str(shape)
         ])
 
-    @QtCore.pyqtSlot(int)
+    @Slot(int)
     def _processCbChange(self, _):
         self.emitSelection()
 

--- a/plottr/gui/widgets.py
+++ b/plottr/gui/widgets.py
@@ -7,7 +7,7 @@ Common GUI widgets that are re-used across plottr.
 from typing import Union, List, Tuple, Optional, Type, Sequence, Dict
 
 from .tools import dictToTreeWidgetItems
-from plottr import QtCore, Flowchart, QtWidgets
+from plottr import QtCore, Flowchart, QtWidgets, Signal, Slot
 from plottr.node import Node, linearFlowchart
 from ..plot import PlotNode, PlotWidgetContainer, MPLAutoPlot
 
@@ -46,7 +46,7 @@ class MonitorIntervalInput(QtWidgets.QWidget):
     of the spinbox has changed.
     """
 
-    intervalChanged = QtCore.pyqtSignal(int)
+    intervalChanged = Signal(int)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -58,7 +58,7 @@ class MonitorIntervalInput(QtWidgets.QWidget):
 
         self.spin.valueChanged.connect(self.spinValueChanged)
 
-    @QtCore.pyqtSlot(int)
+    @Slot(int)
     def spinValueChanged(self, val):
         self.intervalChanged.emit(val)
 

--- a/plottr/log.py
+++ b/plottr/log.py
@@ -12,7 +12,7 @@ widget will capture the log and display it.
 # TODO: unify with the one from instrumentserver. should maybe go into labcore?
 
 import sys
-from PyQt5 import QtWidgets, QtGui
+from plottr import QtWidgets, QtGui
 import logging
 
 __author__ = 'Wolfgang Pfaff'

--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .node import Node, updateOption, NodeWidget
 from ..data.datadict import MeshgridDataDict, DataDict, DataDictBase
-from .. import QtGui, QtCore, QtWidgets
+from .. import QtCore, QtWidgets, Signal, Slot
 from plottr.icons import xySelectIcon
 
 __author__ = 'Wolfgang Pfaff'
@@ -69,7 +69,7 @@ class DimensionAssignmentWidget(QtWidgets.QTreeWidget):
     This needs to be done by inheriting classes.
     """
 
-    rolesChanged = QtCore.pyqtSignal(object)
+    rolesChanged = Signal(object)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -242,7 +242,7 @@ class DimensionAssignmentWidget(QtWidgets.QTreeWidget):
             }
         return ret
 
-    @QtCore.pyqtSlot(str, str)
+    @Slot(str, str)
     def setDimInfo(self, dim: str, info: str = ''):
         try:
             item = self.findItems(dim, QtCore.Qt.MatchExactly, 0)[0]
@@ -250,7 +250,7 @@ class DimensionAssignmentWidget(QtWidgets.QTreeWidget):
         except IndexError:
             pass
 
-    @QtCore.pyqtSlot(dict)
+    @Slot(dict)
     def setDimInfos(self, infos: Dict[str, str]):
         for ax, info in infos.items():
             self.setInfo(ax, info)
@@ -420,7 +420,7 @@ class DimensionReducer(Node):
 
     #: A signal that emits (structure, shapes, type) when data structure has
     #: changed.
-    newDataStructure = QtCore.pyqtSignal(object, object, object)
+    newDataStructure = Signal(object, object, object)
 
     def __init__(self, *arg, **kw):
         self._reductions = {}

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -166,7 +166,7 @@ class ShapeSpecificationWidget(QtWidgets.QWidget):
         self.confirm.setEnabled(enable)
 
 
-class GridOptionWidget(QtGui.QWidget):
+class GridOptionWidget(QtWidgets.QWidget):
     """A widget that allows the user to specify how to grid data."""
 
     optionSelected = Signal(object)

--- a/plottr/node/node.py
+++ b/plottr/node/node.py
@@ -121,7 +121,7 @@ class Node(NodeBase):
 
     #: A signal to notify the UI of option changes
     #: arguments is a dictionary of options and new values.
-    optionChangeNotification = QtCore.pyqtSignal(dict)
+    optionChangeNotification = Signal(dict)
 
     #: signal emitted when available data axes change
     #: emits a the list of names of new axes
@@ -141,7 +141,7 @@ class Node(NodeBase):
     dataShapesChanged = Signal(dict)
 
     #: when data structure changes, emits (structure, shapes, type)
-    newDataStructure = QtCore.pyqtSignal(object, object, object)
+    newDataStructure = Signal(object, object, object)
 
     #: developer flag for whether we actually want to raise of use the logging
     #: system
@@ -327,10 +327,10 @@ class NodeWidget(QtWidgets.QWidget):
 
     #: signal (args: object)) to emit to notify the node of a (changed)
     #: user option.
-    optionToNode = QtCore.pyqtSignal(object)
+    optionToNode = Signal(object)
 
     #: signal (args: (object)) all options to the node.
-    allOptionsToNode = QtCore.pyqtSignal(object)
+    allOptionsToNode = Signal(object)
 
     def __init__(self, parent: QtWidgets.QWidget = None,
                  embedWidgetClass: Type[QtWidgets.QWidget] = None,
@@ -372,7 +372,7 @@ class NodeWidget(QtWidgets.QWidget):
         """
         self.optSetters[opt](value)
 
-    @QtCore.pyqtSlot(dict)
+    @Slot(dict)
     def setOptionsFromNode(self, opts: Dict[str, Any]):
         """Set all options without triggering updates back to the node."""
         for opt, val in opts.items():


### PR DESCRIPTION
* Fix one missed use of QWidget from QtGui
* Change one remaining import of pyqt5 directly to use the inport from plottr.
* Use Signal and Slot names imported from plottr rather than specific pyqt5 names


This is all in preperation for eventually being able to also support pyside2 as a backend