### PR TITLE
Fix a matplotlib warning

### DIFF
--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -876,7 +876,7 @@ class AutoPlot(_MPLPlotWidget):
 
         self._plotData(adjustSize=True)
 
-    def _makeAxes(self, nAxes: int) -> Axes:
+    def _makeAxes(self, nAxes: int) -> List[Axes]:
         """Create a grid of axes.
         We try to keep the grid as square as possible.
         """

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -881,7 +881,7 @@ class AutoPlot(_MPLPlotWidget):
         We try to keep the grid as square as possible.
         """
         nrows = int(nAxes ** .5 + .5)
-        ncols = np.ceil(nAxes / nrows)
+        ncols = int(np.ceil(nAxes / nrows))
         axes = self.plot.clearFig(nrows, ncols, nAxes)
         return axes
 


### PR DESCRIPTION
ncols was being passed to axes as a float. This will be an error in future versions of matplotlib. Also fixed a typing issue that I happend to spot at the same time