### PR TITLE
Type check qt interfaces with the PyQt5 stubs

### DIFF
--- a/plottr/__init__.py
+++ b/plottr/__init__.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING
 import os
 
-from qtpy import QtCore, QtGui, QtWidgets
-
-Signal = QtCore.Signal
-Slot = QtCore.Slot
+if TYPE_CHECKING:
+    from PyQt5 import QtCore, QtGui, QtWidgets
+    Signal = QtCore.pyqtSignal
+    Slot = QtCore.pyqtSlot
+else:
+    from qtpy import QtCore, QtGui, QtWidgets
+    Signal = QtCore.Signal
+    Slot = QtCore.Slot
 
 from pyqtgraph.flowchart import Flowchart as pgFlowchart, Node as pgNode
 Flowchart = pgFlowchart

--- a/plottr/apps/ui/monitr.py
+++ b/plottr/apps/ui/monitr.py
@@ -57,7 +57,10 @@ class DataFileContent(QtWidgets.QTreeWidget):
             metaParent = QtWidgets.QTreeWidgetItem(grpItem, ['[META]'])
 
             for dn, dv in grpData.data_items():
-                vals = [grpData.label(dn), str(grpData.meta_val('shape', dn))]
+                label = grpData.label(dn)
+                assert label is not None
+                vals = [label, str(grpData.meta_val('shape', dn))]
+
                 if dn in grpData.dependents():
                     vals.append(f'Data (depends on {str(tuple(grpData.axes(dn)))[1:]}')
                 else:

--- a/plottr/node/autonode.py
+++ b/plottr/node/autonode.py
@@ -52,8 +52,8 @@ class AutoNodeGui(AutoNodeGuiTemplate):
 
     def __init__(self, parent=None, node=None):
         super().__init__(parent)
-        self.layout = QtWidgets.QFormLayout()
-        self.setLayout(self.layout)
+        layout = QtWidgets.QFormLayout()
+        self.setLayout(layout)
 
     def addOption(self, name: str, specs: Dict[str, Any], confirm: bool):
         optionType = specs.get('type', None)
@@ -62,12 +62,12 @@ class AutoNodeGui(AutoNodeGuiTemplate):
         if func is not None:
             widget = func(self, name, specs, confirm)
 
-        self.layout.addRow(name, widget)
+        self.layout().addRow(name, widget)
 
     def addConfirm(self):
         widget = QtWidgets.QPushButton('Confirm')
         widget.pressed.connect(self.signalAllOptions)
-        self.layout.addRow('', widget)
+        self.layout().addRow('', widget)
 
 
 class AutoNode(Node):

--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -210,12 +210,12 @@ class DimensionAssignmentWidget(QtWidgets.QTreeWidget):
                     w.deleteLater()
                     self.choices[dim]['optionsWidget'] = None
 
-            self.setItemWidget(item, 2, None)
+            self.setItemWidget(item, 2, QtWidgets.QWidget())
             self.setDimInfo(dim, '')
 
             self._currentRoles[dim] = {
-                'role' : role,
-                'options' : {},
+                'role': role,
+                'options': {},
             }
 
     def getRole(self, name: str) -> Tuple[str, Dict]:

--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -416,7 +416,7 @@ class DimensionReducer(Node):
     """
 
     nodeName = 'DimensionReducer'
-    uiClass = DimensionReducerNodeWidget
+    uiClass: Type["NodeWidget"] = DimensionReducerNodeWidget
 
     #: A signal that emits (structure, shapes, type) when data structure has
     #: changed.

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -55,10 +55,10 @@ class ShapeSpecificationWidget(QtWidgets.QWidget):
         self._widgets = {}
         self._processChanges = True
 
-        self.layout = QtWidgets.QFormLayout()
+        layout = QtWidgets.QFormLayout()
         self.confirm = QtWidgets.QPushButton('set')
-        self.layout.addRow(self.confirm)
-        self.setLayout(self.layout)
+        layout.addRow(self.confirm)
+        self.setLayout(layout)
 
         self.confirm.clicked.connect(self.signalShape)
 
@@ -79,7 +79,7 @@ class ShapeSpecificationWidget(QtWidgets.QWidget):
             'name': nameWidget,
             'shape': dimLenWidget,
         }
-        self.layout.insertRow(idx, nameWidget, dimLenWidget)
+        self.layout().insertRow(idx, nameWidget, dimLenWidget)
 
         nameWidget.currentTextChanged.connect(
             lambda x: self._processAxisChange(idx, x)
@@ -94,10 +94,10 @@ class ShapeSpecificationWidget(QtWidgets.QWidget):
         if axes != self._axes:
             self._axes = axes
 
-            for i in range(self.layout.rowCount() - 1):
+            for i in range(self.layout().rowCount() - 1):
                 self._widgets[i]['name'].deleteLater()
                 self._widgets[i]['shape'].deleteLater()
-                self.layout.removeRow(0)
+                self.layout().removeRow(0)
 
             self._widgets = {}
 

--- a/plottr/node/node.py
+++ b/plottr/node/node.py
@@ -320,7 +320,7 @@ class NodeWidget(QtWidgets.QWidget):
     """
 
     #: icon for this node
-    icon = None
+    icon: Optional[QtGui.QIcon] = None
 
     #: preferred location of the widget when used as dock widget
     preferredDockWidgetArea = QtCore.Qt.LeftDockWidgetArea

--- a/plottr/plot/base.py
+++ b/plottr/plot/base.py
@@ -71,8 +71,9 @@ class PlotWidgetContainer(QtWidgets.QWidget):
         self.plotWidget: Optional["PlotWidget"] = None
         self.data: Optional[DataDictBase] = None
 
-        self.layout = QtWidgets.QVBoxLayout(self)
-        self.layout.setContentsMargins(0, 0, 0, 0)
+        layout: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
 
     def setPlotWidget(self, widget: "PlotWidget"):
         """Set the plot widget.
@@ -88,12 +89,12 @@ class PlotWidgetContainer(QtWidgets.QWidget):
             return
 
         if self.plotWidget is not None:
-            self.layout.removeWidget(self.plotWidget)
+            self.layout().removeWidget(self.plotWidget)
             self.plotWidget.deleteLater()
 
         self.plotWidget = widget
         if self.plotWidget is not None:
-            self.layout.addWidget(widget)
+            self.layout().addWidget(widget)
             self.plotWidget.setData(self.data)
 
     def setData(self, data: DataDictBase):

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -5,7 +5,7 @@ plottr/plot/mpl.py : Tools for plotting with matplotlib.
 import logging
 import io
 from enum import Enum, unique, auto
-from typing import Dict, List, Tuple, Union, cast, Optional
+from typing import Dict, List, Tuple, Union, cast, Optional, Type
 from collections import OrderedDict
 
 # standard scientific computing imports
@@ -557,7 +557,7 @@ class _MPLPlotWidget(PlotWidget):
     Per default, add a canvas and the matplotlib NavBar.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent=parent)
 
         setMplDefaults()
@@ -752,7 +752,7 @@ class AutoPlot(_MPLPlotWidget):
     whereas magnitude and phase are separated into two panels.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent=parent)
 
         self.plotDataType = PlotDataType.unknown
@@ -760,7 +760,7 @@ class AutoPlot(_MPLPlotWidget):
         self.complexRepresentation = ComplexRepresentation.real
         self.complexPreference = ComplexRepresentation.realAndImag
 
-        self.dataType = type(None)
+        self.dataType: Optional[Type[DataDictBase]] = None
         self.dataStructure = None
         self.dataShapes = None
         self.dataLimits = None
@@ -782,7 +782,10 @@ class AutoPlot(_MPLPlotWidget):
 
     def _analyzeData(self, data: Optional[DataDictBase]) -> Dict[str, bool]:
         """checks data and compares with previous properties."""
-        dataType = type(data)
+        if data is not None:
+            dataType: Optional[Type[DataDictBase]] = type(data)
+        else:
+            dataType = None
 
         if data is None:
             dataStructure = None

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -567,9 +567,10 @@ class _MPLPlotWidget(PlotWidget):
         self.addMplBarOptions()
         self.mplBar.setIconSize(QtCore.QSize(16,16))
 
-        self.layout = QtWidgets.QVBoxLayout(self)
-        self.layout.addWidget(self.plot)
-        self.layout.addWidget(self.mplBar)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.plot)
+        layout.addWidget(self.mplBar)
+        self.setLayout(layout)
 
     def setMeta(self, data: DataDictBase):
         if data.has_meta('title'):
@@ -766,7 +767,7 @@ class AutoPlot(_MPLPlotWidget):
 
         # A toolbar for configuring the plot
         self.plotOptionsToolBar = _AutoPlotToolBar('Plot options', self)
-        self.layout.insertWidget(1, self.plotOptionsToolBar)
+        self.layout().insertWidget(1, self.plotOptionsToolBar)
 
         self.plotOptionsToolBar.plotTypeSelected.connect(
             self._plotTypeFromToolBar

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -652,7 +652,7 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
 
         self.plotComplexPolar = self.addAction('Mag/Phase')
         self.plotComplexPolar.setCheckable(True)
-        self.plotComplexPolar.triggered.connect(self.complexPolarSelected)
+        self.plotComplexPolar.triggered.connect(self._trigger_complex_mag_phase)
 
         self.plotTypeActions = OrderedDict({
             PlotType.multitraces: self.plotasMultiTraces,
@@ -664,6 +664,9 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
 
         self._currentPlotType = PlotType.empty
         self._currentlyAllowedPlotTypes: Tuple[PlotType, ...] = ()
+
+    def _trigger_complex_mag_phase(self, enable: bool):
+        self.complexPolarSelected.emit(enable)
 
     def selectPlotType(self, plotType: PlotType):
         """makes sure that the selected `plotType` is active (checked), all

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ qcodes
 pytest
 pytest-qt
 mypy
+PyQt5-stubs


### PR DESCRIPTION
This is done on top of #125  which should be merged first.

The main change is that QWidget.layout is a getter for the layout. Plottr used to overwrite this with an attribute reprecenting the layout. Here we change that to use the getter following the QWidget interface