### PR TITLE
Simplify typing by clarifying that data_vals must return a numpy array

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -43,6 +43,7 @@ def meta_name_to_key(name: str) -> str:
 
 T = TypeVar('T', bound='DataDictBase')
 
+
 class DataDictBase(dict):
     """
     Simple data storage class that is based on a regular dictionary.
@@ -174,7 +175,7 @@ class DataDictBase(dict):
                         n = k
                     yield n, v
 
-    def data_vals(self, key: str) -> Union[Sequence, np.ndarray]:
+    def data_vals(self, key: str) -> np.ndarray:
         """
         Return the data values of field ``key``.
 
@@ -641,7 +642,6 @@ class DataDictBase(dict):
         ret = self.copy()
         for d, _ in self.data_items():
             arr = self.data_vals(d)
-            assert isinstance(arr, np.ndarray)
             vals = np.ma.masked_where(num.is_invalid(arr), arr, copy=True)
             try:
                 vals.fill_value = np.nan
@@ -895,7 +895,6 @@ class DataDict(DataDictBase):
                 rows = self.data_vals(d)
             else:
                 datavals = self.data_vals(d)
-                assert isinstance(datavals, np.ndarray)
                 rows = datavals.reshape(-1, np.prod(ishp[d]))
 
             _idxs = np.array([])
@@ -1084,7 +1083,6 @@ def guess_shape_from_datadict(data: DataDict) -> \
         axes: Dict[str, np.ndarray] = {}
         for a in axnames:
             axdata = data.data_vals(a)
-            assert isinstance(axdata, np.ndarray)
             axes[a] = axdata
         shapes[d] = num.guess_grid_from_sweep_direction(**axes)
 

--- a/plottr/node/data_selector.py
+++ b/plottr/node/data_selector.py
@@ -148,7 +148,6 @@ class DataSelector(Node):
         if self.force_numerical_data:
             for d, _ in ret.data_items():
                 d_data_vals = ret.data_vals(d)
-                assert isinstance(d_data_vals, np.ndarray)
                 dt = num.largest_numtype(d_data_vals,
                                          include_integers=False)
                 if dt is not None:

--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -531,7 +531,6 @@ class DimensionReducer(Node):
                     # the dimensions of the coordinate meshes
                     for ax in data[n]['axes']:
                         axdata = data.data_vals(ax)
-                        assert isinstance(axdata, np.ndarray)
                         if len(axdata.shape) > len(targetShape):
                             newaxvals = funCall(data[ax]['values'], *arg, **kw)
                             data[ax]['values'] = newaxvals

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -802,7 +802,6 @@ class AutoPlot(_MPLPlotWidget):
             dataLimits = {}
             for n in data.axes() + data.dependents():
                 vals = data.data_vals(n)
-                assert isinstance(vals, np.ndarray)
                 dataLimits[n] = vals.min(), vals.max()
 
         result = {


### PR DESCRIPTION
This allows us to remove a bunch of asserts on the type