### PR TITLE
Add squeeze axis, and alwasy create optionsWidget when it is None

### DIFF
--- a/plottr/node/dim_reducer.py
+++ b/plottr/node/dim_reducer.py
@@ -44,7 +44,7 @@ def selectAxisElement(arr: np.ndarray, index: int, axis: int) -> np.ndarray:
     :param axis: dimension on which to perform the reduction
     :return: reduced array
     """
-    return np.squeeze(sliceAxis(arr, np.s_[index:index+1:], axis))
+    return np.squeeze(sliceAxis(arr, np.s_[index:index+1:], axis), axis=axis)
 
 
 # Translation between reduction functions and convenient naming
@@ -296,7 +296,8 @@ class DimensionReductionAssignmentWidget(DimensionAssignmentWidget):
             value = kw.get('index', 0)
 
             # only create the slider widget if it doesn't exist yet
-            if self.itemWidget(item, 2) is None:
+            if (self.itemWidget(item, 2) is None) or \
+                    (self.choices[dim]['optionsWidget'] is None):
                 assert self._dataStructure is not None
                 assert self._dataShapes is not None
                 # get the number of elements in this dimension

--- a/test/pytest/test_dim_reducer.py
+++ b/test/pytest/test_dim_reducer.py
@@ -1,9 +1,26 @@
 import numpy as np
 
 from plottr.data.datadict import MeshgridDataDict
-from plottr.node.dim_reducer import DimensionReducer, ReductionMethod, XYSelector
+from plottr.node.dim_reducer import DimensionReducer, ReductionMethod, XYSelector, \
+    selectAxisElement
 from plottr.node.tools import linearFlowchart
 from plottr.utils import num
+
+
+def test_selectAxisElement():
+    """
+    When one of the dimension only has one element, it should not be removed
+    by np.squeeze.
+    The data in the test has shape of (2, 3, 1), and the vals after applying
+    function "selectAxisElement" (on axis 0) should have shape (3,1), not (3,).
+    """
+    data = np.array([[[1], [2], [3]], [[4], [5], [6]]])
+    axis_to_reduce = 0
+    targetShape_list = list(data.shape)
+    del targetShape_list[axis_to_reduce]
+    targetShape = tuple(targetShape_list)
+    vals = selectAxisElement(data, index=0, axis=axis_to_reduce)
+    assert vals.shape == targetShape
 
 
 def test_reduction(qtbot):


### PR DESCRIPTION
The is PR is trying to fix two problems:
1. when dealing with data that have more than two dimensions, the function `selectAxisElement` will return vals with unexpected shape. For example:
> data = np.array([[[1], [2], [3]], [[4], [5], [6]]])    # shape is (2, 3, 1)
axis_to_reduce = 0
targetShape_list = list(data.shape)  # copied from line 512 of dim_reducer.py
del targetShape_list[axis_to_reduce]
targetShape = tuple(targetShape_list)    # target shape is (3,1)
vals = selectAxisElement(data, index=0, axis=axis_to_reduce)    # the shape is (3,), instead of expected (3,1).

With the change (adding `axis=axis` to `np.squeeze`), the new shape will be (3,1), same as expected. I have checked that it also works with 2D data.

2. (Again, this is for data with more than 2 dimensions) I noticed that when switching dimensions, the slider widget `self.choices[dim]['optionsWidget']` is not created. My guess is, the `setRole` is only checking if the slider is there for the first two pre-selected dimensions. To fix it, I add an `or` condition. However, this may not be the best way to fix it, I'm open to suggestions here.