### PR TITLE
avoid reloading qcodes dataset on refresh

### DIFF
--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -228,6 +228,7 @@ class QCodesDSLoader(Node):
         if val != self.pathAndId:
             self._pathAndId = val
             self.nLoadedRecords = 0
+            self._dataset = None
 
     def process(self, dataIn: Optional[DataDictBase] = None) -> Optional[Dict[str, Any]]:
         if dataIn is not None:

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -211,7 +211,7 @@ class QCodesDSLoader(Node):
     def __init__(self, *arg: Any, **kw: Any):
         self._pathAndId: Tuple[Optional[str], Optional[int]] = (None, None)
         self.nLoadedRecords = 0
-        self._dataset = None
+        self._dataset: Optional[DataSet] = None
 
         super().__init__(*arg, **kw)
 


### PR DESCRIPTION
If we reload the dataset every single time we refresh we loose the benefit of the cache that can gradually load the data 