### PR TITLE
Use qcodes labels for plots

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -88,7 +88,7 @@ class DataDictBase(dict):
                 return False
 
             if self[dn].get('label', '') != other[dn].get('label', ''):
-                # print(f"different units for {dn}")
+                # print(f"different labels for {dn}")
                 return False
 
             if self[dn].get('axes', []) != other[dn].get('axes', []):
@@ -401,6 +401,8 @@ class DataDictBase(dict):
         """
         Get a label for a data field.
 
+        If label is present, use the label for the data; otherwise 
+        fallback to use data name as the label.
         If a unit is present, this is the name with the unit appended in
         brackets: ``name (unit)``; if no unit is present, just the name.
 
@@ -505,6 +507,7 @@ class DataDictBase(dict):
 
         Other tasks performed:
             * ``unit`` keys are created if omitted
+            * ``label`` keys are created if omitted
             * ``shape`` meta information is updated with the correct values
               (only if present already).
 

--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -87,6 +87,10 @@ class DataDictBase(dict):
                 # print(f"different units for {dn}")
                 return False
 
+            if self[dn].get('label', '') != other[dn].get('label', ''):
+                # print(f"different units for {dn}")
+                return False
+
             if self[dn].get('axes', []) != other[dn].get('axes', []):
                 # print(f"different axes for {dn}")
                 return False
@@ -406,8 +410,12 @@ class DataDictBase(dict):
         if self.validate():
             if name not in self:
                 raise ValueError("No field '{}' present.".format(name))
+            
+            if self[name]['label'] != '':
+                n = self[name]['label']
+            else:
+                n = name
 
-            n = name
             if self[name]['unit'] != '':
                 n += ' ({})'.format(self[name]['unit'])
 
@@ -521,6 +529,9 @@ class DataDictBase(dict):
 
             if 'unit' not in v:
                 v['unit'] = ''
+
+            if 'label' not in v:
+                v['label'] = ''
 
             vals = v.get('values', [])
             if type(vals) not in [np.ndarray, np.ma.core.MaskedArray]:

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -43,11 +43,13 @@ def get_ds_structure(ds: 'DataSet') -> Dict[str, Any]:
         {
             'dependent_parameter_name': {
                 'unit': unit,
+                'label': label,
                 'axes': list of names of independent parameters,
                 'values': []
             },
             'independent_parameter_name': {
                 'unit': unit,
+                'label': label,
                 'values': []
             },
             ...
@@ -66,7 +68,7 @@ def get_ds_structure(ds: 'DataSet') -> Dict[str, Any]:
 
     for spec in paramspecs:
         if spec.name not in standalones:
-            structure[spec.name] = {'unit': spec.unit, 'values': []}
+            structure[spec.name] = {'unit': spec.unit, 'label': spec.label, 'values': []}
             if len(spec.depends_on_) > 0:
                 structure[spec.name]['axes'] = list(spec.depends_on_)
 
@@ -185,10 +187,10 @@ def ds_to_datadicts(ds: 'DataSet') -> Dict[str, DataDict]:
         if spec.depends_on != '':
             axes = spec.depends_on_
             data = dict()
-            data[p] = dict(unit=spec.unit, axes=axes, values=pdata[p][p])
+            data[p] = dict(unit=spec.unit, label=spec.label, axes=axes, values=pdata[p][p])
             for ax in axes:
                 axspec = ds.paramspecs[ax]
-                data[ax] = dict(unit=axspec.unit, values=pdata[p][ax])
+                data[ax] = dict(unit=axspec.unit, label=axspec.label, values=pdata[p][ax])
             ret[p] = DataDict(**data)
             ret[p].validate()
 

--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -32,15 +32,13 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
 
     def _makeItem(self, name: str) -> QtWidgets.QTreeWidgetItem:
         shape = self._dataShapes.get(name, tuple())
-        unit = self._dataStructure[name].get('unit', '')
-        label = f"{name} [{unit}]"
+        label = f"{name} [{self._dataStructure.label(name)}]"
         deps = "("
         for i, d in enumerate(self._dataStructure.axes(name)):
             if i > 0:
                 deps += ", "
-            axunit = self._dataStructure[d].get('unit', '')
-            axlabel = f"{d} [{axunit}]"
-            deps += axlabel
+            axlabel = self._dataStructure.label(d)
+            deps += f"{d} [{axlabel}]"
         deps += ")"
 
         return QtWidgets.QTreeWidgetItem([

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -139,7 +139,7 @@ def test_get_ds_structure(experiment):
     N = 5
 
     m = qc.Measurement(exp=experiment)
-    m.register_custom_parameter('x', unit='cm')
+    m.register_custom_parameter('x', unit='cm',label='my_x_param')
     m.register_custom_parameter('y')
 
     # check that unused parameters don't mess with
@@ -155,10 +155,12 @@ def test_get_ds_structure(experiment):
     expected_structure = {
         'x': {
             'unit': 'cm',
+            'label': 'my_x_param',
             'values': []
         },
         'y': {
             'unit': '',
+            'label': '',
             'values': []
         }
         # note that parameter 'foo' is not expected to be included
@@ -168,6 +170,7 @@ def test_get_ds_structure(experiment):
         expected_structure.update(
             {f'z_{n}': {
                 'unit': '',
+                'label': '',
                 'axes': ['x', 'y'],
                 'values': []
                 }


### PR DESCRIPTION
Set plots to use qcodes labels when available instead of the parameter names for plotting. Might want to add a bit more information in doc strings but wanted to get the PR up in case there are other reasons to not merge this.

Think this addresses #69 