### PR TITLE
Use logger name to get logger

### DIFF
--- a/plottr/node/node.py
+++ b/plottr/node/node.py
@@ -230,9 +230,8 @@ class Node(NodeBase):
 
         :return: logger with a name that can be traced back easily to this node.
         """
-        name = self.__module__ + '.' + self.__class__.__name__ + '.' \
-               + self.name()
-        logger = log.getLogger()
+        name = f"{self.__module__}.{self.__class__.__name__}.{self.name()}"
+        logger = log.getLogger(name)
         logger.setLevel(log.LEVEL)
         return logger
 


### PR DESCRIPTION
And simplify name generation

The logger should probably just be an instance attibute but that improvement is left for another pr. 