### PR TITLE
fallback to no grid when a grid cannot be set

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -44,6 +44,10 @@ def meta_name_to_key(name: str) -> str:
 T = TypeVar('T', bound='DataDictBase')
 
 
+class GriddingError(ValueError):
+    pass
+
+
 class DataDictBase(dict):
     """
     Simple data storage class that is based on a regular dictionary.
@@ -1125,6 +1129,7 @@ def datadict_to_meshgrid(data: DataDict,
     :param use_existing_shape: if ``True``, simply use the shape that the data
         already has. For numpy-array data, this might already be present.
         if ``False``, flatten and reshape.
+    :raises: GriddingError (subclass of ValueError) if the data cannot be gridded.
     :returns: the generated ``MeshgridDataDict``.
     """
 
@@ -1133,7 +1138,7 @@ def datadict_to_meshgrid(data: DataDict,
         return MeshgridDataDict()
 
     if not data.axes_are_compatible():
-        raise ValueError('Non-compatible axes, cannot grid that.')
+        raise GriddingError('Non-compatible axes, cannot grid that.')
 
     if not use_existing_shape and data.is_expandable():
         data = data.expand()
@@ -1146,10 +1151,10 @@ def datadict_to_meshgrid(data: DataDict,
         shps = set(order_shape[1] if order_shape is not None
                    else None for order_shape in shp_specs.values())
         if len(shps) > 1:
-            raise ValueError('Cannot determine unique shape for all data.')
+            raise GriddingError('Cannot determine unique shape for all data.')
         ret = list(shp_specs.values())[0]
         if ret is None:
-            raise ValueError('Shape could not be inferred.')
+            raise GriddingError('Shape could not be inferred.')
         # the guess-function returns both axis order as well as shape.
         inner_axis_order, target_shape = ret
 

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -11,7 +11,7 @@ from typing import Tuple, Dict, Any, List, Union, Optional, Sequence
 from plottr import QtGui, Signal, Slot, QtWidgets
 from .node import Node, NodeWidget, updateOption, updateGuiFromNode
 from ..data import datadict as dd
-from ..data.datadict import DataDict, MeshgridDataDict, DataDictBase
+from ..data.datadict import DataDict, MeshgridDataDict, DataDictBase, GriddingError
 from plottr.icons import get_gridIcon
 
 __author__ = 'Wolfgang Pfaff'
@@ -37,6 +37,7 @@ class GridOption(Enum):
 
     #: read the shape from DataSet Metadata (if available)
     metadataShape = 3
+
 
 class ShapeSpecificationWidget(QtWidgets.QWidget):
     """A widget that allows the user to specify a grid shape.
@@ -470,20 +471,25 @@ class DataGridder(Node):
         order = opts.get('order', data.axes())
 
         if isinstance(data, DataDict):
-            if method is GridOption.noGrid:
+            try:
+                if method is GridOption.noGrid:
+                    dout = data.expand()
+                elif method is GridOption.guessShape:
+                    dout = dd.datadict_to_meshgrid(data)
+                elif method is GridOption.specifyShape:
+                    dout = dd.datadict_to_meshgrid(
+                        data, target_shape=opts['shape'],
+                        inner_axis_order=order,
+                    )
+                elif method is GridOption.metadataShape:
+                    dout = dd.datadict_to_meshgrid(
+                        data, use_existing_shape=True
+                    )
+            except GriddingError:
                 dout = data.expand()
-            elif method is GridOption.guessShape:
-                dout = dd.datadict_to_meshgrid(data)
-            elif method is GridOption.specifyShape:
-                dout = dd.datadict_to_meshgrid(
-                    data, target_shape=opts['shape'],
-                    inner_axis_order=order,
-                )
-            elif method is GridOption.metadataShape:
-                dout = dd.datadict_to_meshgrid(
-                    data, use_existing_shape=True
-                )
-
+                self.logger().info("data could not be gridded. Falling back "
+                                   "to no grid")
+                self.ui.setGrid((GridOption.noGrid, {}))
         elif isinstance(data, MeshgridDataDict):
             if method is GridOption.noGrid:
                 dout = dd.meshgrid_to_datadict(data)

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -489,7 +489,8 @@ class DataGridder(Node):
                 dout = data.expand()
                 self.logger().info("data could not be gridded. Falling back "
                                    "to no grid")
-                self.ui.setGrid((GridOption.noGrid, {}))
+                if self.ui is not None:
+                    self.ui.setGrid((GridOption.noGrid, {}))
         elif isinstance(data, MeshgridDataDict):
             if method is GridOption.noGrid:
                 dout = dd.meshgrid_to_datadict(data)


### PR DESCRIPTION
To make the logic a bit more clean make the error in `datadict_to_meshgrid` a subclass of the original error. 