### PR TITLE
work around numpy deprecation warning

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -915,9 +915,9 @@ class DataDict(DataDictBase):
 
             # get indices of all rows that are fully None
             if len(ishp[d]) == 0:
-                _newidxs = np.where(rows is None)[0]
+                _newidxs = np.atleast_1d(np.asarray(rows is None)).nonzero()[0]
             else:
-                _newidxs = np.where(np.all(rows is None, axis=-1))[0]
+                _newidxs = np.atleast_1d(np.asarray(np.all(rows is None, axis=-1))).nonzero()[0]
             _idxs = np.append(_idxs, _newidxs)
 
             # get indices for all rows that are fully NaN. works only


### PR DESCRIPTION
Calling nonzero on a 0d array is deprecated. 

If you read the docs of np.where it turns out that the one argument form of this
is equivalent to `np.asarray(condition).nonzero()`
so follow the advise in the deprecation warning and rewrite this to `np.atleast_1d(np.asarray(condition)).nonzero()`