### PR TITLE
Add node to scale units using enginering prefixes

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -19,6 +19,7 @@ from ..gui.widgets import MonitorIntervalInput, SnapshotWidget
 from ..node.data_selector import DataSelector
 from ..node.dim_reducer import XYSelector
 from ..node.filter.correct_offset import SubtractAverage
+from ..node.scaleunits import ScaleUnits
 from ..node.grid import DataGridder, GridOption
 from ..node.tools import linearFlowchart
 from ..node.node import Node
@@ -299,6 +300,7 @@ def autoplotQcodesDataset(log: bool = False,
         ('Grid', DataGridder),
         ('Dimension assignment', XYSelector),
         ('Subtract average', SubtractAverage),
+        ('Scale units', ScaleUnits),
         ('plot', PlotNode)
     )
 

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -65,7 +65,7 @@ class ScaleUnits(Node):
 
     @state.setter  # type: ignore[misc]
     @updateOption('state')
-    def averagingAxis(self, value: str) -> None:
+    def state(self, value: str) -> None:
         self._state = value
 
     def process(self, dataIn: Optional[DataDictBase]=None) -> Optional[Dict[str, Optional[DataDictBase]]]:

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -68,5 +68,5 @@ class ScaleUnits(Node):
     def state(self, value: str) -> None:
         self._state = value
 
-    def process(self, dataIn: Optional[DataDictBase]=None) -> Optional[Dict[str, Optional[DataDictBase]]]:
+    def process(self, dataIn: Optional[DataDictBase] = None) -> Optional[Dict[str, Optional[DataDictBase]]]:
         return dict(dataOut=dataIn)

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -2,7 +2,7 @@ from enum import Enum, unique
 from typing import Optional, Dict
 
 try:
-    from qcodes.utils.plotting import find_scale_and_prefix
+    from qcodes.utils.plotting import find_scale_and_prefix  #  type: ignore[attr-defined]
 except ImportError:
     # fallback for qcodes < 0.21
     from plottr.utils.find_scale_and_prefix import find_scale_and_prefix
@@ -112,6 +112,7 @@ class ScaleUnits(Node):
     def process(self, dataIn: Optional[DataDictBase] = None) -> Optional[Dict[str, Optional[DataDictBase]]]:
         if super().process(dataIn=dataIn) is None:
             return None
+        assert dataIn is not None
         data = dataIn.copy()
 
         for name, data_item in data.data_items():

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -124,8 +124,8 @@ class ScaleUnits(Node):
         assert dataIn is not None
         data = dataIn.copy()
 
-        for name, data_item in data.data_items():
-            if self.scale_unit_option != ScaleUnitsOption.never:
+        if self.scale_unit_option != ScaleUnitsOption.never:
+            for name, data_item in data.data_items():        
                 prefix, selected_scale = find_scale_and_prefix(
                     data_item['values'],
                     data_item["unit"]

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -23,6 +23,7 @@ class ScaleUnitsOption(Enum):
 
 
 class ScaleUnitOptionWidget(QtWidgets.QWidget):
+    """A widget that allows the user to specify if units should be scaled."""
 
     unitscaleselected = Signal(ScaleUnitsOption)
 
@@ -60,6 +61,7 @@ class ScaleUnitOptionWidget(QtWidgets.QWidget):
 
 
 class ScaleUnitsWidget(NodeWidget):
+    """Node widget for :class:`ScaleUnits`."""
 
     def __init__(self, node: Optional[Node] = None):
         super().__init__(node=node, embedWidgetClass=ScaleUnitOptionWidget)
@@ -92,7 +94,13 @@ class ScaleUnitsWidget(NodeWidget):
 
 
 class ScaleUnits(Node):
-
+    """
+    A Node that automatically scales the units and values such that
+    for example 1e-9 V will be rendered as 1 nV. The logic for how to scale units
+    in inherited from QCoDeS. Basically pure SI units are scaled with enginering prefixes
+    while more complex units are scaled by adding a power of 10 prefix to the unit
+    e.g (1*10**3 complexunit)
+    """
     useUi = True
     uiClass = ScaleUnitsWidget
 
@@ -123,7 +131,5 @@ class ScaleUnits(Node):
                 )
                 data_item["unit"] = prefix + data_item["unit"]
                 data_item['values'] = data_item['values'] * 10**(-selected_scale)
-
-            # todo handle categorical data
 
         return dict(dataOut=data)

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -1,6 +1,7 @@
 from enum import Enum, unique
 from typing import Optional, Dict
 
+from plottr import QtWidgets
 from plottr.node import Node, NodeWidget, updateOption
 from plottr.data.datadict import DataDictBase
 
@@ -18,10 +19,35 @@ class StateOption(Enum):
     always = 2
 
 
+class ScaleUnitOptionWidget(QtWidgets.QWidget):
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(parent)
+
+        self.buttons = {
+            StateOption.never: QtWidgets.QRadioButton('Never'),
+            StateOption.simpleunits: QtWidgets.QRadioButton('Simple Units'),
+            StateOption.always: QtWidgets.QRadioButton('Always'),
+        }
+        btnLayout = QtWidgets.QVBoxLayout()
+        self.btnGroup = QtWidgets.QButtonGroup(self)
+
+        for opt in StateOption:
+            btn = self.buttons[opt]
+            self.btnGroup.addButton(btn, opt.value)
+            btnLayout.addWidget(btn)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(btnLayout)
+        layout.addStretch()
+        self.setLayout(layout)
+        self.buttons[StateOption.never].setChecked(True)
+
+
 class ScaleUnitsWidget(NodeWidget):
 
     def __init__(self, node: Optional[Node] = None):
-        super().__init__(node=node, embedWidgetClass=None)
+        super().__init__(node=node, embedWidgetClass=ScaleUnitOptionWidget)
 
 
 class ScaleUnits(Node):

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -1,0 +1,46 @@
+from enum import Enum, unique
+from typing import Optional, Dict
+
+from plottr.node import Node, NodeWidget, updateOption
+from plottr.data.datadict import DataDictBase
+
+@unique
+class StateOption(Enum):
+    """Options for how to scale units."""
+
+    #: do not scale units
+    never = 0
+
+    #: only simple units
+    simpleunits = 1
+
+    #: all units
+    always = 2
+
+
+class ScaleUnitsWidget(NodeWidget):
+
+    def __init__(self, node: Optional[Node] = None):
+        super().__init__(node=node, embedWidgetClass=None)
+
+
+class ScaleUnits(Node):
+
+    useUi = True
+    uiClass = ScaleUnitsWidget
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._state: Optional[str] = None
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter  # type: ignore[misc]
+    @updateOption('state')
+    def averagingAxis(self, value: str) -> None:
+        self._state = value
+
+    def process(self, dataIn: Optional[DataDictBase]=None) -> Optional[Dict[str, Optional[DataDictBase]]]:
+        return dict(dataOut=dataIn)

--- a/plottr/node/scaleunits.py
+++ b/plottr/node/scaleunits.py
@@ -11,6 +11,7 @@ from plottr import QtWidgets, Signal, Slot
 from plottr.node import Node, NodeWidget, updateOption
 from plottr.data.datadict import DataDictBase
 
+
 @unique
 class ScaleUnitsOption(Enum):
     """Options for how to scale units."""
@@ -25,7 +26,7 @@ class ScaleUnitsOption(Enum):
 class ScaleUnitOptionWidget(QtWidgets.QWidget):
     """A widget that allows the user to specify if units should be scaled."""
 
-    unitscaleselected = Signal(ScaleUnitsOption)
+    unit_scale_selected = Signal(ScaleUnitsOption)
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
@@ -57,7 +58,7 @@ class ScaleUnitOptionWidget(QtWidgets.QWidget):
             checked: bool
     ) -> None:
         if checked:
-            self.unitscaleselected.emit(ScaleUnitsOption(self.btnGroup.id(btn)))
+            self.unit_scale_selected.emit(ScaleUnitsOption(self.btnGroup.id(btn)))
 
 
 class ScaleUnitsWidget(NodeWidget):
@@ -66,7 +67,7 @@ class ScaleUnitsWidget(NodeWidget):
     def __init__(self, node: Optional[Node] = None):
         super().__init__(node=node, embedWidgetClass=ScaleUnitOptionWidget)
         assert self.widget is not None
-        self.widget.unitscaleselected.connect(
+        self.widget.unit_scale_selected.connect(
             lambda x: self.signalOption('scale_unit_option')
         )
 

--- a/plottr/utils/find_scale_and_prefix.py
+++ b/plottr/utils/find_scale_and_prefix.py
@@ -48,15 +48,16 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
     and matching scale that best describes the data.
 
     The units for which unit prefixes are added can be found in
-    `_UNITS_FOR_RESCALING`. For all other units
-    the prefix is an exponential scaling factor e.g. `10^3 `.
+    ``_UNITS_FOR_RESCALING``. For all other units
+    the prefix is an exponential scaling factor e.g. ``10^3``.
 
     Args:
         data: A numpy array of data.
         unit: The unit the data is measured in.
             Should not contain a prefix already.
 
-    Returns: tuple of prefix and exponential scale
+    Returns:
+        tuple of prefix and exponential scale
 
     """
     maxval = np.nanmax(np.abs(data))
@@ -67,7 +68,7 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
                 selected_scale = 0
                 prefix = _ENGINEERING_PREFIXES[selected_scale]
                 break
-            elif maxval < threshold:
+            if maxval < threshold:
                 selected_scale = scale
                 prefix = _ENGINEERING_PREFIXES[scale]
                 break

--- a/plottr/utils/find_scale_and_prefix.py
+++ b/plottr/utils/find_scale_and_prefix.py
@@ -1,0 +1,88 @@
+"""
+Fallback module can be removed once we drop support for qcodes < 0.21
+"""
+
+from collections import OrderedDict
+from typing import Set, Dict, Tuple
+
+import numpy as np
+
+
+_UNITS_FOR_RESCALING: Set[str] = {
+    # SI units (without some irrelevant ones like candela)
+    # 'kg' is not included because it is 'kilo' and rarely used
+    'm', 's', 'A', 'K', 'mol', 'rad', 'Hz', 'N', 'Pa', 'J',
+    'W', 'C', 'V', 'F', 'ohm', 'Ohm', 'Ω',
+    '\N{GREEK CAPITAL LETTER OMEGA}', 'S', 'Wb', 'T', 'H',
+    # non-SI units as well, for convenience
+    'eV', 'g'
+}
+
+_ENGINEERING_PREFIXES: Dict[int, str] = OrderedDict({
+    -24: "y",
+    -21: "z",
+    -18: "a",
+    -15: "f",
+    -12: "p",
+     -9: "n",
+     -6: "\N{GREEK SMALL LETTER MU}",
+     -3: "m",
+      0: "",
+      3: "k",
+      6: "M",
+      9: "G",
+     12: "T",
+     15: "P",
+     18: "E",
+     21: "Z",
+     24: "Y"
+})
+
+_THRESHOLDS: Dict[float, int] = OrderedDict(
+    {10**(scale + 3): scale for scale in _ENGINEERING_PREFIXES.keys()})
+
+
+def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
+    """
+    Given a numpy array of data and a unit find the best engineering prefix
+    and matching scale that best describes the data.
+
+    The units for which unit prefixes are added can be found in
+    `_UNITS_FOR_RESCALING`. For all other units
+    the prefix is an exponential scaling factor e.g. `10^3 `.
+
+    Args:
+        data: A numpy array of data.
+        unit: The unit the data is measured in.
+            Should not contain a prefix already.
+
+    Returns: tuple of prefix and exponential scale
+
+    """
+    maxval = np.nanmax(np.abs(data))
+    if unit in _UNITS_FOR_RESCALING:
+        for threshold, scale in _THRESHOLDS.items():
+            if maxval == 0.0:
+                # handle all zero data
+                selected_scale = 0
+                prefix = _ENGINEERING_PREFIXES[selected_scale]
+                break
+            elif maxval < threshold:
+                selected_scale = scale
+                prefix = _ENGINEERING_PREFIXES[scale]
+                break
+        else:
+            # here, maxval is larger than the largest threshold
+            largest_scale = max(list(_ENGINEERING_PREFIXES.keys()))
+            selected_scale = largest_scale
+            prefix = _ENGINEERING_PREFIXES[largest_scale]
+    else:
+        if maxval > 0:
+            selected_scale = 3 * (np.floor(np.floor(np.log10(maxval)) / 3))
+        else:
+            selected_scale = 0
+        if selected_scale != 0:
+            prefix = f'$10^{{{selected_scale:.0f}}}$ '
+        else:
+            prefix = ''
+    return prefix, selected_scale

--- a/plottr/utils/find_scale_and_prefix.py
+++ b/plottr/utils/find_scale_and_prefix.py
@@ -77,7 +77,7 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
             largest_scale = max(list(_ENGINEERING_PREFIXES.keys()))
             selected_scale = largest_scale
             prefix = _ENGINEERING_PREFIXES[largest_scale]
-    else:
+    elif unit != "":
         if maxval > 0:
             selected_scale = 3 * (np.floor(np.floor(np.log10(maxval)) / 3))
         else:
@@ -86,4 +86,7 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
             prefix = f'$10^{{{selected_scale:.0f}}}$ '
         else:
             prefix = ''
+    else:
+        prefix = ""
+        selected_scale = 0
     return prefix, selected_scale

--- a/plottr/utils/find_scale_and_prefix.py
+++ b/plottr/utils/find_scale_and_prefix.py
@@ -50,7 +50,7 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
     The units for which unit prefixes are added can be found in
     ``_UNITS_FOR_RESCALING``. For all other units
     the prefix is an exponential scaling factor e.g. ``10^3``.
-    If no unit is given (e.g. an empty string) no scaling is performed.
+    If no unit is given (i.e. an empty string) no scaling is performed.
 
     Args:
         data: A numpy array of data.

--- a/plottr/utils/find_scale_and_prefix.py
+++ b/plottr/utils/find_scale_and_prefix.py
@@ -50,6 +50,7 @@ def find_scale_and_prefix(data: np.ndarray, unit: str) -> Tuple[str, int]:
     The units for which unit prefixes are added can be found in
     ``_UNITS_FOR_RESCALING``. For all other units
     the prefix is an exponential scaling factor e.g. ``10^3``.
+    If no unit is given (e.g. an empty string) no scaling is performed.
 
     Args:
         data: A numpy array of data.

--- a/test/pytest/test_qcodes_flow.py
+++ b/test/pytest/test_qcodes_flow.py
@@ -9,6 +9,7 @@ from plottr.node.tools import linearFlowchart
 from plottr.data.qcodes_dataset import QCodesDSLoader
 from plottr.node.data_selector import DataSelector
 from plottr.node.grid import DataGridder, GridOption
+from plottr.node.scaleunits import ScaleUnits
 
 
 @pytest.mark.skipif(version.parse(qc.__version__)
@@ -20,6 +21,7 @@ def test_qcodes_flow_shaped_data(qtbot, dataset_with_shape):
         ('Data loader', QCodesDSLoader),
         ('Data selection', DataSelector),
         ('Grid', DataGridder),
+        ('Scale Units', ScaleUnits)
     )
     loader = fc.nodes()['Data loader']
     selector = fc.nodes()['Data selection']

--- a/test/pytest/test_scale_units.py
+++ b/test/pytest/test_scale_units.py
@@ -1,0 +1,51 @@
+from numpy.testing import assert_allclose
+
+from plottr.data.datadict import DataDict
+from plottr.node.tools import linearFlowchart
+from plottr.node.scaleunits import ScaleUnits
+
+import numpy as np
+
+
+def test_basic_scale_units(qtbot):
+
+    ScaleUnits.useUi = False
+    ScaleUnits.uiClass = None
+
+    fc = linearFlowchart(('scale_units', ScaleUnits))
+    node = fc.nodes()['scale_units']
+
+    x = np.arange(0, 5.0e-9, 1.0e-9)
+    y = np.linspace(0, 1e9, 5)
+    z = np.arange(4.0e6, 6.0e6, 1.0e6)
+    xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+    vv = xx * yy * zz
+    x1d, y1d, z1d = xx.flatten(), yy.flatten(), zz.flatten()
+    v1d = vv.flatten()
+    data = DataDict(
+        x=dict(values=x1d, unit='V'),
+        y=dict(values=y1d, unit="A"),
+        z=dict(values=z1d, unit="Foobar"),
+        vals=dict(values=v1d, axes=['x', 'y', 'z'])
+    )
+    assert data.validate()
+
+    fc.setInput(dataIn=data)
+
+    output = fc.outputValues()['dataOut']
+
+    assert output['x']['unit'] == 'nV'
+    assert_allclose(output['x']["values"],
+                    (xx*1e9).ravel())
+
+    assert output['y']['unit'] == 'GA'
+    assert_allclose(output['y']["values"],
+                    (yy / 1e9).ravel())
+
+    assert output['z']["unit"] == '$10^{6}$ Foobar'
+    assert_allclose(output['z']["values"],
+                    (zz / 1e6).ravel())
+
+    assert output['vals']['unit'] == ''
+    assert_allclose(output['vals']['values'],
+                    vv.flatten())


### PR DESCRIPTION
Based on the logic implemented in qcodes. The logic in qcodes has been refactored in https://github.com/QCoDeS/Qcodes/pull/2480
to support older versions we bundle the same code here for now until older versions of qcodes are no longer supported. 