### PR TITLE
only trigger a refresh of runs if there are changes to update

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -406,6 +406,9 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
                 self.loadDBProcess.setPath(self.filepath)
 
     def DBLoaded(self, dbdf: pandas.DataFrame) -> None:
+        if dbdf.equals(self.dbdf):
+            logger().debug('DB reloaded with no changes. Skipping update')
+            return None
         self.dbdf = dbdf
         self.dbdfUpdated.emit()
         self.dateList.sendSelectedDates()


### PR DESCRIPTION
This saves cpu time and prevents the mouse from losing focus of a selected run. 
It would also make sense to further optimize the update of single runs such that an update to a single run (number of points, complete time etc) only updates that line but does not trigger a full redraw of the run browser