### PR TITLE
In data selection widget, only display label (not also name)

### DIFF
--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -33,7 +33,7 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
     def _makeItem(self, name: str) -> QtWidgets.QTreeWidgetItem:
         shape = self._dataShapes.get(name, tuple())
         label = f"{self._dataStructure.label(name)}"
-        axlabels = [self._dataStructure.label(d) for d in
+        axlabels = [str(self._dataStructure.label(d)) for d in
                     self._dataStructure.axes(name)]
         deps = ", ".join(axlabels)
 

--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -33,12 +33,9 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
     def _makeItem(self, name: str) -> QtWidgets.QTreeWidgetItem:
         shape = self._dataShapes.get(name, tuple())
         label = f"{self._dataStructure.label(name)}"
-        deps = ""
-        for i, d in enumerate(self._dataStructure.axes(name)):
-            if i > 0:
-                deps += ", "
-            axlabel = self._dataStructure.label(d)
-            deps += f"{axlabel}"
+        axlabels = [self._dataStructure.label(d) for d in
+                    self._dataStructure.axes(name)]
+        deps = ", ".join(axlabels)
 
         return QtWidgets.QTreeWidgetItem([
             label, deps, str(shape)

--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -32,14 +32,13 @@ class DataSelectionWidget(QtWidgets.QTreeWidget):
 
     def _makeItem(self, name: str) -> QtWidgets.QTreeWidgetItem:
         shape = self._dataShapes.get(name, tuple())
-        label = f"{name} [{self._dataStructure.label(name)}]"
-        deps = "("
+        label = f"{self._dataStructure.label(name)}"
+        deps = ""
         for i, d in enumerate(self._dataStructure.axes(name)):
             if i > 0:
                 deps += ", "
             axlabel = self._dataStructure.label(d)
-            deps += f"{d} [{axlabel}]"
-        deps += ")"
+            deps += f"{axlabel}"
 
         return QtWidgets.QTreeWidgetItem([
             label, deps, str(shape)


### PR DESCRIPTION
avoids redundancy and makes the widget content more legible.