### PR TITLE
Added functionality of choosing between Re/Im and Re in 2D complex plots

### DIFF
--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -955,7 +955,9 @@ class AutoPlot(_MPLPlotWidget):
                 ComplexRepresentation.magAndPhase,
             )
         else:
-            self.plotOptionsToolBar.setAllowedComplexTypes(None)
+            self.plotOptionsToolBar.setAllowedComplexTypes(
+                ComplexRepresentation.empty
+            )
 
     @Slot(PlotType)
     def _plotTypeFromToolBar(self, plotType: PlotType) -> None:

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -91,9 +91,6 @@ class PlotType(Enum):
 class ComplexRepresentation(Enum):
     """Options for plotting complex-valued data."""
 
-    #: no complex defined
-    empty = auto()
-    
     #: real and imaginary
     realAndImag = auto()
 
@@ -691,7 +688,8 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
         self._currentPlotType = PlotType.empty
         self._currentlyAllowedPlotTypes: Tuple[PlotType, ...] = ()
 
-        self._currentComplex = ComplexRepresentation.empty
+        self._currentComplex = ComplexRepresentation.realAndImag
+        self.ComplexActions[self._currentComplex].setChecked(True)
         self._currentlyAllowedComplexTypes: Tuple[ComplexRepresentation, ...] = ()
 
     def selectPlotType(self, plotType: PlotType) -> None:
@@ -744,7 +742,7 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
 
         self._currentlyAllowedPlotTypes = args
 
-    def selectComplexType(self, comp:ComplexRepresentation) -> None:
+    def selectComplexType(self, comp: ComplexRepresentation) -> None:
         """makes sure that the selected `comp` is active (checked), all
         others are not active.
 
@@ -770,7 +768,7 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
         If the current selection is now disabled, instead select the first
         enabled one.
         """
-
+        
         if args == self._currentlyAllowedComplexTypes:
             return
 
@@ -782,7 +780,7 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
                 v.setEnabled(True)
 
         if self._currentComplex not in args:
-            self._currentComplex = ComplexRepresentation.empty
+            self._currentComplex = ComplexRepresentation.realAndImag
             for k, v in self.ComplexActions.items():
                 if k in args:
                     v.setChecked(True)
@@ -947,17 +945,18 @@ class AutoPlot(_MPLPlotWidget):
             self.plotOptionsToolBar.setAllowedPlotTypes()
 
     def _processComplexTypeOptions(self) -> None:
-        """Given the current data type, figure out what the complex options are."""
-        if self.dataIsComplex() == True:
-            self.plotOptionsToolBar.setAllowedComplexTypes(
-                ComplexRepresentation.realAndImag,
-                ComplexRepresentation.real,
-                ComplexRepresentation.magAndPhase,
-            )
-        else:
-            self.plotOptionsToolBar.setAllowedComplexTypes(
-                ComplexRepresentation.empty
-            )
+        """Given data is complex or not, define what complex options to be selected."""
+        if self.data is not None:
+            if self.dataIsComplex() == True:
+                self.plotOptionsToolBar.setAllowedComplexTypes(
+                    ComplexRepresentation.realAndImag,
+                    ComplexRepresentation.real,
+                    ComplexRepresentation.magAndPhase,
+                )
+            else:
+                self.plotOptionsToolBar.setAllowedComplexTypes(
+                    ComplexRepresentation.real
+                )
 
     @Slot(PlotType)
     def _plotTypeFromToolBar(self, plotType: PlotType) -> None:

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -951,9 +951,9 @@ class AutoPlot(_MPLPlotWidget):
         else:
             if ComplexRepresentation.realAndImag:
                 self.complexRepresentation is ComplexRepresentation.realAndImag
-            if self.complexRepresentation is ComplexRepresentation.real:
+            if ComplexRepresentation.real:
                 self.complexRepresentation is ComplexRepresentation.real
-            if self.complexRepresentation is ComplexRepresentation.magAndPhase:
+            if ComplexRepresentation.magAndPhase:
                 self.complexRepresentation is ComplexRepresentation.magAndPhase
 
         if self.plotType is PlotType.multitraces:

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -91,15 +91,14 @@ class PlotType(Enum):
 class ComplexRepresentation(Enum):
     """Options for plotting complex-valued data."""
 
+    #: only real
+    real = auto()
+
     #: real and imaginary
     realAndImag = auto()
 
-    #: only real
-    real = auto()
-    
     #: magnitude and phase
     magAndPhase = auto()
-
 
 def determinePlotDataType(data: Optional[DataDictBase]) -> PlotDataType:
     """
@@ -656,15 +655,15 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
         # other options
         self.addSeparator()
 
-        self.plotComplexReIm = self.addAction('Real/Imag')
-        self.plotComplexReIm.setCheckable(True)
-        self.plotComplexReIm.triggered.connect(
-            lambda: self.selectComplexType(ComplexRepresentation.realAndImag))
-
         self.plotReal = self.addAction('Real')
         self.plotReal.setCheckable(True)
         self.plotReal.triggered.connect(
             lambda: self.selectComplexType(ComplexRepresentation.real))
+
+        self.plotComplexReIm = self.addAction('Real/Imag')
+        self.plotComplexReIm.setCheckable(True)
+        self.plotComplexReIm.triggered.connect(
+            lambda: self.selectComplexType(ComplexRepresentation.realAndImag))
 
         self.plotMagPhase = self.addAction('Mag/Phase')
         self.plotMagPhase.setCheckable(True)
@@ -680,8 +679,8 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
         })
 
         self.ComplexActions = OrderedDict({
-            ComplexRepresentation.realAndImag: self.plotComplexReIm,
             ComplexRepresentation.real: self.plotReal,
+            ComplexRepresentation.realAndImag: self.plotComplexReIm,
             ComplexRepresentation.magAndPhase: self.plotMagPhase
         })
 
@@ -949,8 +948,8 @@ class AutoPlot(_MPLPlotWidget):
         if self.data is not None:
             if self.dataIsComplex() == True:
                 self.plotOptionsToolBar.setAllowedComplexTypes(
-                    ComplexRepresentation.realAndImag,
                     ComplexRepresentation.real,
+                    ComplexRepresentation.realAndImag,
                     ComplexRepresentation.magAndPhase,
                 )
             else:

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -762,33 +762,33 @@ class _AutoPlotToolBar(QtWidgets.QToolBar):
             self._currentComplex = comp
             self.complexPolarSelected.emit(self._currentComplex)
 
-    def setAllowedComplexTypes(self, *args: ComplexRepresentation) -> None:
+    def setAllowedComplexTypes(self, *complexOptions: ComplexRepresentation) -> None:
         """Disable all choices that are not allowed.
         If the current selection is now disabled, instead select the first
         enabled one.
         """
         
-        if args == self._currentlyAllowedComplexTypes:
+        if complexOptions == self._currentlyAllowedComplexTypes:
             return
 
         for k, v in self.ComplexActions.items():
-            if k not in args:
+            if k not in complexOptions:
                 v.setChecked(False)
                 v.setEnabled(False)
             else:
                 v.setEnabled(True)
 
-        if self._currentComplex not in args:
+        if self._currentComplex not in complexOptions:
             self._currentComplex = ComplexRepresentation.realAndImag
             for k, v in self.ComplexActions.items():
-                if k in args:
+                if k in complexOptions:
                     v.setChecked(True)
                     self._currentComplex = k
                     break
 
             self.complexPolarSelected.emit(self._currentComplex)
 
-        self._currentlyAllowedComplexTypes = args
+        self._currentlyAllowedComplexTypes = complexOptions
 
 class AutoPlot(_MPLPlotWidget):
     """A widget for plotting with matplotlib.


### PR DESCRIPTION
This PR suggests the following:

- Two new buttons (Real/Imag and Real) added to have more control for complex 2D plots
- It dynamically switches between Real/Imag, Real and Mag/Phase (selecting one button, disables the other buttons in this category)
- It works consistent with other controls like PlotType, e.g., it is possible to change PlotType together with this new added buttons.

It is tested and working as it should.

The following can be worked later to have more improvements and functionalities related to this topic:
- Imag button can be added with the functionality for showing only imaginary.
- For now, only 2D plots can be used with these new buttons. 1D plots are still showing real and imaginary parts in one figure. This could be improved later.
- The default behavior of 2D plot is Real/Imag, but the Real/Imag button is not activated by default. It is a minor thing, but it's nice to have.