### PR TITLE
Remove y-axis label from single panel

### DIFF
--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -1033,12 +1033,11 @@ class AutoPlot(_MPLPlotWidget):
             nAxes = 1
         axes = self._makeAxes(nAxes)
 
-        if len(depvals) > 1:
-            ylbl = self.data.label(depnames[0])
-            phlbl: Optional[str] = f"Arg({depnames[0]})"
-        else:
-            ylbl = None
-            phlbl = None
+        # For singlepanel, y-axis label might be different for different plots,
+        # so we set it to None. Instead of y-axis label, each plot shows the y-axis
+        # label and unit as a legend inside the plot using curveLabel. 
+        ylbl = None
+        phlbl: Optional[str] = None
 
         for yname, yvals in zip(depnames, depvals):
             # otherwise we sometimes raise ComplexWarning. This is basically just

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -1035,10 +1035,10 @@ class AutoPlot(_MPLPlotWidget):
 
         if len(depvals) > 1:
             ylbl = None
-            phlbl = None
+            phlbl: Optional[str] = None
         else:
             ylbl = self.data.label(depnames[0])
-            phlbl: Optional[str] = f"Arg({depnames[0]})"
+            phlbl = f"Arg({depnames[0]})"
             
 
         for yname, yvals in zip(depnames, depvals):

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -1034,10 +1034,10 @@ class AutoPlot(_MPLPlotWidget):
         axes = self._makeAxes(nAxes)
 
         # For singlepanel, y-axis label might be different for different plots,
-        # so we set it to None. Instead of y-axis label, each plot shows the y-axis
+        # so we keep it empty. Instead of y-axis label, each plot shows the y-axis
         # label and unit as a legend inside the plot using curveLabel. 
-        ylbl = None
-        phlbl: Optional[str] = None
+        ylbl = ""
+        phlbl: Optional[str] = ""
 
         for yname, yvals in zip(depnames, depvals):
             # otherwise we sometimes raise ComplexWarning. This is basically just

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -1033,11 +1033,13 @@ class AutoPlot(_MPLPlotWidget):
             nAxes = 1
         axes = self._makeAxes(nAxes)
 
-        # For singlepanel, y-axis label might be different for different plots,
-        # so we keep it empty. Instead of y-axis label, each plot shows the y-axis
-        # label and unit as a legend inside the plot using curveLabel. 
-        ylbl = ""
-        phlbl: Optional[str] = ""
+        if len(depvals) > 1:
+            ylbl = None
+            phlbl = None
+        else:
+            ylbl = self.data.label(depnames[0])
+            phlbl: Optional[str] = f"Arg({depnames[0]})"
+            
 
         for yname, yvals in zip(depnames, depvals):
             # otherwise we sometimes raise ComplexWarning. This is basically just

--- a/plottr/plot/mpl.py
+++ b/plottr/plot/mpl.py
@@ -1055,7 +1055,7 @@ class AutoPlot(_MPLPlotWidget):
                                 addLegend=(yname == depnames[-1]))
                     plot1dTrace(axes[1], xvals, np.asanyarray(yvals).imag,
                                 axLabels=(self.data.label(xname), ylbl),
-                                curveLabel=f"Im({yname})",
+                                curveLabel=f"Im({self.data.label(yname)})",
                                 addLegend=(yname == depnames[-1]))
                 elif self.complexRepresentation is ComplexRepresentation.magAndPhase:
                     plot1dTrace(axes[0], xvals, np.real(np.abs(yvals)),


### PR DESCRIPTION
This PR:
Removes y-axis label from single panel view as it becomes problematic when multiple plots selected (y-axis might have different names and/ or scales for different plots). y-axis doesn't show anything with this PR, instead it continues to show each figure label and unit as a legend inside the plot. 

There is one problem which is not related to this change, however it is nice to be solved in this PR:

- [x] If data is complex, only the left plot shows the scale in the legend of the plot (the left plot is the real part, but this problem is not related to the real and imaginary parts of data), the right plot scale works, but it doesn't show the unit scale inside the plot legend.
The problem seems to be solved in a deeper level than mpl.py and I couldn't figure it out yet.