### PR TITLE
Modernize setup

### DIFF
--- a/plottr/py.typed
+++ b/plottr/py.typed
@@ -1,0 +1,2 @@
+this file marks plottr as safe for typechecking
+https://mypy.readthedocs.io/en/latest/installed_packages.html#installed-packages

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,59 @@
+[metadata]
+name = plottr
+description = A tool for live plotting and processing data
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Wolfgang Pfaff
+author_email = wolfgangpfff@gmail.com
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+license = MIT
+url = https://github.com/toolsforexperiments/plottr
+project_urls =
+    Documentation = https://plottr.readthedocs.io
+    Source = https://github.com/toolsforexperiments/plottr/
+    Tracker = https://github.com/toolsforexperiments/plottr/issues
+
+[options]
+packages = find:
+python_requires = >=3.7
+install_requires =
+    pandas>=0.22
+    xarray
+    pyqtgraph>=0.10.0
+    matplotlib
+    numpy
+    lmfit
+    h5py>=2.10.0
+    qtpy>=1.9.0
+    typing-extensions>=3.7.4.3
+    packaging>=20.0
+
+[options.package_data]
+plottr =
+ resource/gfx/*
+
+[options.extras_require]
+PyQt5 = PyQt5
+PySide2 = PySide2
+
+[options.packages.find]
+include =
+    plottr*
+
+
+[options.entry_points]
+console_scripts =
+    plottr-monitr = plottr.apps.monitr:script
+    plottr-inspectr = plottr.apps.inspectr:script
+    plottr-autoplot-ddh5 = plottr.apps.autoplot:script
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,8 @@ install_requires =
 
 [options.package_data]
 plottr =
- resource/gfx/*
+    resource/gfx/*
+    py.typed
 
 [options.extras_require]
 PyQt5 = PyQt5

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 license = MIT
 url = https://github.com/toolsforexperiments/plottr
@@ -46,7 +47,6 @@ PySide2 = PySide2
 [options.packages.find]
 include =
     plottr*
-
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 import versioneer
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
 setup(
-    name='plottr',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description='A tool for live plotting and processing data',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author='Wolfgang Pfaff',
-    author_email='wolfgangpfff@gmail.com',
-    url='https://github.com/toolsforexperiments/plottr',
-    packages=find_packages(include=("plottr*",)),
-    package_data={'plottr': ['resource/gfx/*']},
-    install_requires=[
-        'pandas>=0.22',
-        'xarray',
-        'pyqtgraph>=0.10.0',
-        'matplotlib',
-        'numpy',
-        'lmfit',
-        'h5py>=2.10.0',
-        'qtpy>=1.9.0',
-        'typing-extensions>=3.7.4.3',
-        "packaging>=20.0",
-    ],
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Scientific/Engineering'
-    ],
-    python_requires='>=3.7',
-    extras_require={'PyQt5': "PyQt5", "PySide2": "PySide2"},
-    entry_points={
-        "console_scripts": [
-            "plottr-monitr = plottr.apps.monitr:script",
-            "plottr-inspectr = plottr.apps.inspectr:script",
-            "plottr-autoplot-ddh5 = plottr.apps.autoplot:script",
-        ],
-    }
 )


### PR DESCRIPTION
* Move static data from code (setup.py) to a config file setup.cfg
* Add a few more links to issues and docs. These will render as part of the sidebar on pypi
* Add classifier for python 3.9
* Mark as type checkable by downstream projects (by adding a py.typed file)