### PR TITLE
Fix rgba error

### DIFF
--- a/plottr/plot/mpl/plotting.py
+++ b/plottr/plot/mpl/plotting.py
@@ -125,7 +125,7 @@ def colorplot2d(ax: Axes,
     elif plotType is PlotType.colormesh:
         im = ppcolormesh_from_meshgrid(ax, x, y, z, cmap=cmap, **kw)
     elif plotType is PlotType.scatter2d:
-        im = ax.scatter(x, y, c=z, cmap=cmap, **kw)
+        im = ax.scatter(x.squeeze(), y.squeeze(), c=z.squeeze(), cmap=cmap, **kw)
     else:
         im = None
 

--- a/plottr/plot/mpl/plotting.py
+++ b/plottr/plot/mpl/plotting.py
@@ -3,7 +3,7 @@
 """
 
 from enum import Enum, auto, unique
-from typing import Optional, Tuple, Any, Union
+from typing import Any, Optional, Tuple, Union
 
 import numpy as np
 from matplotlib import colors, rcParams
@@ -11,8 +11,7 @@ from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
 
 from plottr.utils import num
-from plottr.utils.num import interp_meshgrid_2d, centers2edges_2d
-
+from plottr.utils.num import centers2edges_2d, interp_meshgrid_2d
 
 __author__ = 'Wolfgang Pfaff'
 __license__ = 'MIT'
@@ -125,7 +124,7 @@ def colorplot2d(ax: Axes,
     elif plotType is PlotType.colormesh:
         im = ppcolormesh_from_meshgrid(ax, x, y, z, cmap=cmap, **kw)
     elif plotType is PlotType.scatter2d:
-        im = ax.scatter(x.squeeze(), y.squeeze(), c=z.squeeze(), cmap=cmap, **kw)
+        im = ax.scatter(x.ravel(), y.ravel(), c=z.ravel(), cmap=cmap, **kw)
     else:
         im = None
 

--- a/test/pytest/test_plotting.py
+++ b/test/pytest/test_plotting.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from plottr.plot.mpl.plotting import PlotType, colorplot2d
+
+
+def test_colorplot2d_scatter_rgba_error():
+    """
+    Check that scatter plots are not trying to plot 1x3 and 1x4
+    z arrays as rgb(a) colors.
+
+    """
+    fig, ax = plt.subplots(1, 1)
+    x = np.array([[0.0, 11.11111111, 22.22222222, 33.33333333]])
+    y = np.array(
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        ]
+    )
+    z = np.array([[5.08907021, 4.93923391, 5.11400073, 5.0925613]])
+    colorplot2d(ax, x, y, z, PlotType.scatter2d)
+
+    x = np.array([[0.0, 11.11111111, 22.22222222]])
+    y = np.array([[0.0, 0.0, 0.0]])
+    z = np.array([[5.08907021, 4.93923391, 5.11400073]])
+    colorplot2d(ax, x, y, z, PlotType.scatter2d)


### PR DESCRIPTION
Fixes error like 

```
Traceback (most recent call last):
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\base.py", line 117, in setData
    self.plotWidget.setData(self.data)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\autoplot.py", line 385, in setData
    self._plotData()
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\autoplot.py", line 462, in _plotData
    **kw)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\autoplot.py", line 56, in __exit__
    return super().__exit__(exc_type, exc_value, traceback)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\base.py", line 385, in __exit__
    self._makeSubPlot(id)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\base.py", line 399, in _makeSubPlot
    item.plotReturn = self.plot(item)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\autoplot.py", line 117, in plot
    return self.plotImage(plotItem)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\autoplot.py", line 135, in plotImage
    im = colorplot2d(axes[0], x, y, z, plotType=self.plotType)
  File "c:\users\jenielse\source\repos\plottr\plottr\plot\mpl\plotting.py", line 131, in colorplot2d
    im = ax.scatter(x.squeeze(), y.squeeze(), c=z.squeeze(), cmap=cmap, **kw)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip\lib\site-packages\matplotlib\__init__.py", line 1361, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip\lib\site-packages\matplotlib\axes\_axes.py", line 4518, in scatter
    get_next_color_func=self._get_patches_for_fill.get_next_color)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip\lib\site-packages\matplotlib\axes\_axes.py", line 4350, in _parse_scatter_color_args
    colors = mcolors.to_rgba_array(c)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip\lib\site-packages\matplotlib\colors.py", line 350, in to_rgba_array
    raise ValueError("RGBA values should be within 0-1 range")
ValueError: RGBA values should be within 0-1 range
```

When trying to do a partial 2d plot that happens to have exactly (1,3) or (1,4) points after cropping. 

You are unlikely to see this issue until #198 is merged as that issue will probably be hit first