### PR TITLE
Add minimal versions to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,9 @@ install_requires =
     pandas>=0.22
     xarray
     pyqtgraph>=0.10.0
-    matplotlib
-    numpy
-    lmfit
+    matplotlib>=3.0.0
+    numpy>=1.12.0
+    lmfit>=1.0
     h5py>=2.10.0
     qtpy>=1.9.0
     typing-extensions>=3.7.4.3
@@ -43,7 +43,7 @@ plottr =
 
 [options.extras_require]
 PyQt5 = PyQt5
-PySide2 = PySide2
+PySide2 = PySide2>=5.12
 
 [options.packages.find]
 include =


### PR DESCRIPTION
i found out that the conda-forge recipe for plottr has stricter version specifications that the pip, so i decide to sync them https://github.com/conda-forge/plottr-feedstock . @jenshnielsen do those versions look correct to you?