### PR TITLE
Feature: tag a run with a star (⭐) or cross (❌) icon

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -145,17 +145,29 @@ class RunList(QtWidgets.QTreeWidget):
         self.itemActivated.connect(self.activateRun)
 
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(self.copy_to_clipboard)
+        self.customContextMenuRequested.connect(self.showContextMenu)
 
     @Slot(QtCore.QPoint)
-    def copy_to_clipboard(self, position: QtCore.QPoint) -> None:
+    def showContextMenu(self, position: QtCore.QPoint) -> None:
+        model_index = self.indexAt(position)
+        item = self.itemFromIndex(model_index)
+        current_tag_char = item.text(1)
+
         menu = QtWidgets.QMenu()
+
         copy_icon = self.style().standardIcon(QtWidgets.QStyle.SP_DialogSaveButton)
         copy_action = menu.addAction(copy_icon, "Copy")
+
+        star_action = self.window().starAction
+        star_action.setText('Star' if current_tag_char != self.tag_dict['star'] else 'Unstar')
+        menu.addAction(star_action)
+
+        trash_action = self.window().trashAction
+        trash_action.setText('Trash' if current_tag_char != self.tag_dict['trash'] else 'Untrash')
+        menu.addAction(trash_action)
+
         action = menu.exec_(self.mapToGlobal(position))
         if action == copy_action:
-            model_index = self.indexAt(position)
-            item = self.itemFromIndex(model_index)
             QtWidgets.QApplication.clipboard().setText(item.text(
                 model_index.column()))
 

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -579,8 +579,8 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         for k, v in structure.items():
             v.pop('values')
         contentInfo = {'Data structure': structure,
-                       'QCoDeS Snapshot': snap,
-                       'Metadata': ds.metadata}
+                       'Metadata': ds.metadata,
+                       'QCoDeS Snapshot': snap}
         self._sendInfo.emit(contentInfo)
 
     @Slot(int)

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -173,7 +173,7 @@ class RunList(QtWidgets.QTreeWidget):
 
     def addRun(self, runId: int, **vals: str) -> None:
         lst = [str(runId)]
-        lst.append(self.tag_dict[vals.get('tag', '')])
+        lst.append(self.tag_dict[vals.get('inspectr_tag', '')])
         lst.append(vals.get('experiment', ''))
         lst.append(vals.get('sample', ''))
         lst.append(vals.get('name', ''))
@@ -192,7 +192,7 @@ class RunList(QtWidgets.QTreeWidget):
         self.setSortingEnabled(False)
 
         for runId, record in selection.items():
-            tag = record.get('tag', '')
+            tag = record.get('inspectr_tag', '')
             if show_only_star and tag != 'star':
                 continue
             elif show_also_trash or tag != 'trash':
@@ -598,10 +598,10 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         assert self.filepath is not None
         runId = int(item.text(0))
         ds = load_dataset_from(self.filepath, runId)
-        ds.add_metadata('tag', tag)
+        ds.add_metadata('inspectr_tag', tag)
 
         # set tag in self.dbdf
-        self.dbdf.at[runId, 'tag'] = tag
+        self.dbdf.at[runId, 'inspectr_tag'] = tag
 
         # set tag in the GUI
         tag_char = self.runList.tag_dict[tag]

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -173,7 +173,8 @@ class RunList(QtWidgets.QTreeWidget):
 
     def addRun(self, runId: int, **vals: str) -> None:
         lst = [str(runId)]
-        lst.append(self.tag_dict[vals.get('inspectr_tag', '')])
+        tag = vals.get('inspectr_tag', '')
+        lst.append(self.tag_dict.get(tag, tag))  # if the tag is not in tag_dict, display in text
         lst.append(vals.get('experiment', ''))
         lst.append(vals.get('sample', ''))
         lst.append(vals.get('name', ''))

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -531,7 +531,8 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         for k, v in structure.items():
             v.pop('values')
         contentInfo = {'Data structure': structure,
-                       'QCoDeS Snapshot': snap}
+                       'QCoDeS Snapshot': snap,
+                       'Metadata': ds.metadata}
         self._sendInfo.emit(contentInfo)
 
     @Slot(int)

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -594,7 +594,7 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         }
         win.showTime()
 
-    def setTag(self, item: QtWidgets.QTreeWidgetItem, tag: str):
+    def setTag(self, item: QtWidgets.QTreeWidgetItem, tag: str) -> None:
         # set tag in the database
         assert self.filepath is not None
         runId = int(item.text(0))
@@ -602,6 +602,7 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         ds.add_metadata('inspectr_tag', tag)
 
         # set tag in self.dbdf
+        assert self.dbdf is not None
         self.dbdf.at[runId, 'inspectr_tag'] = tag
 
         # set tag in the GUI
@@ -611,7 +612,7 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         # refresh the RunInfo widget
         self.setRunSelection(runId)
 
-    def tagSelectedRun(self, tag: str):
+    def tagSelectedRun(self, tag: str) -> None:
         for item in self.runList.selectedItems():
             current_tag_char = item.text(1)
             tag_char = self.runList.tag_dict[tag]
@@ -621,11 +622,11 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
                 self.setTag(item, tag)  # set tag
 
     @Slot()
-    def starSelectedRun(self):
+    def starSelectedRun(self) -> None:
         self.tagSelectedRun('star')
 
     @Slot()
-    def crossSelectedRun(self):
+    def crossSelectedRun(self) -> None:
         self.tagSelectedRun('cross')
 
 

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -600,6 +600,9 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         ds = load_dataset_from(self.filepath, runId)
         ds.add_metadata('tag', tag)
 
+        # set tag in self.dbdf
+        self.dbdf.at[runId, 'tag'] = tag
+
         # set tag in the GUI
         tag_char = self.runList.tag_dict[tag]
         item.setText(1, tag_char)

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -194,7 +194,7 @@ class RunList(QtWidgets.QTreeWidget):
 
         for runId, record in selection.items():
             tag = record.get('inspectr_tag', '')
-            if show_only_star and tag != 'star':
+            if show_only_star and tag == '':
                 continue
             elif show_also_cross or tag != 'cross':
                 self.addRun(runId, **record)

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -129,7 +129,8 @@ class SortableTreeWidgetItem(QtWidgets.QTreeWidgetItem):
 class RunList(QtWidgets.QTreeWidget):
     """Shows the list of runs for a given date selection."""
 
-    cols = ['Run ID', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records', 'GUID']
+    cols = ['Run ID', 'Tag', 'Experiment', 'Sample', 'Name', 'Started', 'Completed', 'Records', 'GUID']
+    tag_dict = {'': '', 'star': '⭐', 'trash': '🗑️'}
 
     runSelected = Signal(int)
     runActivated = Signal(int)
@@ -160,6 +161,7 @@ class RunList(QtWidgets.QTreeWidget):
 
     def addRun(self, runId: int, **vals: str) -> None:
         lst = [str(runId)]
+        lst.append(self.tag_dict[vals.get('tag', '')])
         lst.append(vals.get('experiment', ''))
         lst.append(vals.get('sample', ''))
         lst.append(vals.get('name', ''))

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -366,6 +366,18 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         refreshAction.triggered.connect(self.refreshDB)
         fileMenu.addAction(refreshAction)
 
+        # action: star/unstar the selected run
+        self.starAction = QtWidgets.QAction()
+        self.starAction.setShortcut('Ctrl+Alt+S')
+        self.starAction.triggered.connect(self.starSelectedRun)
+        self.addAction(self.starAction)
+
+        # action: trash/untrash the selected run
+        self.trashAction = QtWidgets.QAction()
+        self.trashAction.setShortcut('Ctrl+Alt+T')
+        self.trashAction.triggered.connect(self.trashSelectedRun)
+        self.addAction(self.trashAction)
+
         # sizing
         scaledSize = 640 * rint(self.logicalDpiX() / 96.0)
         self.resize(scaledSize, scaledSize)
@@ -544,6 +556,37 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
             'window': win,
         }
         win.showTime()
+
+    def setTag(self, item: QtWidgets.QTreeWidgetItem, tag: str):
+        # set tag in the database
+        assert self.filepath is not None
+        runId = int(item.text(0))
+        ds = load_dataset_from(self.filepath, runId)
+        ds.add_metadata('tag', tag)
+
+        # set tag in the GUI
+        tag_char = self.runList.tag_dict[tag]
+        item.setText(1, tag_char)
+
+        # refresh the RunInfo widget
+        self.setRunSelection(runId)
+
+    def tagSelectedRun(self, tag: str):
+        for item in self.runList.selectedItems():
+            current_tag_char = item.text(1)
+            tag_char = self.runList.tag_dict[tag]
+            if current_tag_char == tag_char:  # if already tagged
+                self.setTag(item, '')  # clear tag
+            else:  # if not tagged
+                self.setTag(item, tag)  # set tag
+
+    @Slot()
+    def starSelectedRun(self):
+        self.tagSelectedRun('star')
+
+    @Slot()
+    def trashSelectedRun(self):
+        self.tagSelectedRun('trash')
 
 
 class WindowDict(TypedDict):

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -51,6 +51,7 @@ DataSetStructureDict = Dict[str, Union[IndependentParameterDict, DependentParame
 
 
 class DataSetInfoDict(TypedDict):
+    tag: str
     experiment: str
     sample: str
     name: str
@@ -140,6 +141,7 @@ def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> DataSetInfoDict:
         structure = None
 
     data = DataSetInfoDict(
+        tag=ds.metadata.get('tag', ''),
         experiment=ds.exp_name,
         sample=ds.sample_name,
         name=ds.name,

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -51,7 +51,6 @@ DataSetStructureDict = Dict[str, Union[IndependentParameterDict, DependentParame
 
 
 class DataSetInfoDict(TypedDict):
-    tag: str
     experiment: str
     sample: str
     name: str
@@ -62,6 +61,7 @@ class DataSetInfoDict(TypedDict):
     structure: Optional[DataSetStructureDict]
     records: int
     guid: str
+    inspectr_tag: str
 
 
 # Tools for extracting information on runs in a database
@@ -141,7 +141,6 @@ def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> DataSetInfoDict:
         structure = None
 
     data = DataSetInfoDict(
-        tag=ds.metadata.get('tag', ''),
         experiment=ds.exp_name,
         sample=ds.sample_name,
         name=ds.name,
@@ -151,7 +150,8 @@ def get_ds_info(ds: 'DataSet', get_structure: bool = True) -> DataSetInfoDict:
         started_time=started_time,
         structure=structure,
         records=ds.number_of_results,
-        guid=ds.guid
+        guid=ds.guid,
+        inspectr_tag=ds.metadata.get('inspectr_tag', ''),
     )
 
     return data

--- a/test/pytest/test_qcodes_data.py
+++ b/test/pytest/test_qcodes_data.py
@@ -215,7 +215,8 @@ def test_get_ds_info(experiment):
         'name': 'results',
         'structure': None,
         'records': 0,
-        'guid': dataset.guid
+        'guid': dataset.guid,
+        'inspectr_tag': ''
     }
 
     ds_info = get_ds_info(dataset, get_structure=False)


### PR DESCRIPTION
This PR enables tagging a run with a star (⭐) or trash (🗑️) icon.
We can do this in the right-click menu or by pressing Ctrl-Alt-S or Ctrl-Alt-T.
The tag info is saved in the database.
We can also filter the list of runs based on the tags.
The filtering could be done more efficiently by splitting the `RunList` widget into a `QTableView` and a `QAbstractTableModel` and using a `QSortFilterProxyModel`, but I'll work on this as a separate PR.