### PR TITLE
Use a regular install in tests

### DIFF
--- a/.github/actions/install-dependencies-and-plottr/action.yml
+++ b/.github/actions/install-dependencies-and-plottr/action.yml
@@ -8,5 +8,5 @@ runs:
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         pip install -r test_requirements.txt
-        pip install -e .[pyqt5]
+        pip install .[pyqt5] --use-feature=in-tree-build
       shell: bash


### PR DESCRIPTION
Rather than an editable install. This should make it less likely to forget init files as fixed by #236 