### PR TITLE
Bump minimum version of pyqtgraph

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.7
 install_requires =
     pandas>=0.22
     xarray
-    pyqtgraph>=0.10.0
+    pyqtgraph>=0.12.1
     matplotlib>=3.0.0
     numpy>=1.12.0
     lmfit>=1.0


### PR DESCRIPTION
Fixes #246 246

fixes AttributeError: module 'pyqtgraph' has no attribute 'ColorBarItem'