### PR TITLE
Convert plottr to a pep518 based installation

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -17,9 +17,11 @@ jobs:
       with:
         python-version: '3.7'
     - uses: ./.github/actions/install-dependencies-and-plottr
+    - name: Install build deps
+      run: pip install --upgrade build
     - name: Build
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Install Twine
       run: pip install twine
     - name: Publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools >= 48",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,19 @@ requires = [
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'
+
+[tool.mypy]
+strict_optional = true
+ignore_missing_imports = true
+show_column_numbers = true
+warn_unused_ignores = true
+warn_unused_configs = true
+warn_redundant_casts = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    "plottr._version"
+]
+ignore_errors = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,18 +64,3 @@ versionfile_source = plottr/_version.py
 versionfile_build = plottr/_version.py
 tag_prefix = v
 parentdir_prefix = plottr-
-
-[mypy]
-strict_optional = True
-ignore_missing_imports = True
-show_column_numbers = True
-warn_unused_ignores = True
-warn_unused_configs = True
-warn_redundant_casts = True
-no_implicit_optional = True
-
-[mypy-plottr.*]
-disallow_untyped_defs = True
-
-[mypy-plottr._version]
-ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
+import os
+import sys
+
 from setuptools import setup
 
+# we need to import versioneer from the current dir
+# once versioneer is pep517/518 compliant this can be removed
+sys.path.append(os.path.dirname(__file__))
 import versioneer
 
-setup(
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
-)
+sys.path.pop()
+
+if __name__ == "__main__":
+    setup(
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+    )


### PR DESCRIPTION
Rather than relying on the legacy behavior and use build to produce package 