### PR TITLE
don't reload db while a reload is already in progress

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -520,6 +520,8 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
     @Slot()
     def refreshDB(self) -> None:
         if self.filepath is not None:
+            if self.loadDBThread.isRunning():
+                return
             if self.dbdf is not None and self.dbdf.size > 0:
                 self.latestRunId = self.dbdf.index.values.max()
             else:


### PR DESCRIPTION
I think this resolves https://github.com/toolsforexperiments/plottr/issues/262 by preventing a new reload from overwriting the status of the current reload. @cprosko if you could test that would be great. 