### PR TITLE
Bugfix for clear_meta and expanded has_meta in DataDictBase.

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -189,6 +189,9 @@ class DataDictBase(dict):
         if k in self:
             return True
         else:
+            for key, field_dict in self.data_items():
+                if k in field_dict:
+                    return True
             return False
 
     def meta_val(self, key: str, data: Union[str, None] = None) -> Any:
@@ -244,7 +247,7 @@ class DataDictBase(dict):
         """
         Delete meta information.
 
-        :param data: if this is not None, delete onlymeta information from data
+        :param data: if this is not None, delete only meta information from data
                      field `data`. Else, delete all top-level meta, as well as
                      meta for all data fields.
 
@@ -260,7 +263,8 @@ class DataDictBase(dict):
                     self.delete_meta(m, d)
 
         else:
-            for m, _ in self.meta_items(data):
+            data_meta_list = [m for m, _ in self.meta_items(data)]
+            for m in data_meta_list:
                 self.delete_meta(m, data)
 
     def extract(self: T, data: List[str], include_meta: bool = True,

--- a/test/pytest/test_data_dict_base.py
+++ b/test/pytest/test_data_dict_base.py
@@ -55,12 +55,26 @@ def test_meta():
     assert dd.meta_val('info')(1) == 0
     assert dd.meta_val('@^&', 'x') == 0
 
+    assert dd.has_meta('meta1')
+    assert dd.has_meta('meta3')
+
     for k in ['meta1', 'meta2', '@^&']:
         assert dd.meta_val(k, data='x') == dd['x'][f'__{k}__']
         assert f'__{k}__' in dd['x']
         assert k in [n for n, _ in dd.meta_items('x')]
 
     # test stripping of meta information
+
+    # test stripping specific data field
+
+    dd.clear_meta('x')
+    assert dd.validate()
+    x_nmeta = 0
+    for k, _ in dd['x'].items():
+        if k[:2] == '__' and k[-2:] == '__':
+            x_nmeta += 1
+    assert x_nmeta == 0
+
     dd.clear_meta()
     assert dd.validate()
 


### PR DESCRIPTION
Fixed bug for clear_meta() in DataDictBase: when specifying a data field to clear the meta from, it was deleting it while iterating the array so it was crashing.

Expanded has_meta() so it can look in the meta data of data fields.

Added both things to the testing of meta data