### PR TITLE
pin pyqt5-stubs and mypy to fix typechecking

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 qcodes
 pytest
 pytest-qt
-mypy
-PyQt5-stubs
+mypy==0.950
+PyQt5-stubs==5.15.2.0


### PR DESCRIPTION
Something changed in pyqt5-stubs 5.15.6.0 that broke typechecking.

Since dependabot is already enabled and will upgrade all dependencies we might as well also pin mypy 