### PR TITLE
changed default update time to 0 (not updating)

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -369,7 +369,7 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
     fc.nodes()['Data loader'].filepath = filepath
     fc.nodes()['Data loader'].groupname = groupname
     win.refreshData()
-    win.setMonitorInterval(5.0)
+    win.setMonitorInterval(0.0)
 
     return fc, win
 


### PR DESCRIPTION
In our lab we ran into issues with the default refresh rate for data. It would slow down the startup of data review and was generally tedious to have to turn off manually each time. I just modified the default data refresh rate to be 0.0 from the original value of 5.0. 