### PR TITLE
Save figure bugfix.

### DIFF
--- a/plottr/plot/pyqtgraph/autoplot.py
+++ b/plottr/plot/pyqtgraph/autoplot.py
@@ -9,7 +9,6 @@ object for plotting data automatically using ``pyqtgraph``.
 """
 
 import logging
-import pprint
 from pathlib import Path
 import time
 from dataclasses import dataclass

--- a/plottr/plot/pyqtgraph/autoplot.py
+++ b/plottr/plot/pyqtgraph/autoplot.py
@@ -9,6 +9,7 @@ object for plotting data automatically using ``pyqtgraph``.
 """
 
 import logging
+import pprint
 from pathlib import Path
 import time
 from dataclasses import dataclass
@@ -245,6 +246,7 @@ class AutoPlot(PlotWidget):
         self.fmWidget: Optional[FigureWidget] = None
         self.figConfig: Optional[FigureConfigToolBar] = None
         self.figOptions: FigureOptions = FigureOptions()
+        self.title : Optional[str] = None
 
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -309,6 +311,7 @@ class AutoPlot(PlotWidget):
 
         if self.data.has_meta('title'):
             self.fmWidget.setTitle(self.data.meta_val('title'))
+            self.title = self.data.meta_val('title')
 
     @Slot()
     def _refreshPlot(self) -> None:
@@ -335,12 +338,16 @@ class AutoPlot(PlotWidget):
         assert isinstance(self.fmWidget, FigureWidget)
         assert isinstance(self.data, DataDictBase)
         screenshot = self.fmWidget.grab(rectangle=QtCore.QRect(QtCore.QPoint(0, 0), QtCore.QSize(-1, -1)))
-        path = Path(self.data.meta_val('title'))
-        # add a timestamp here
-        t = time.localtime()
-        time_str = time.strftime(TIMESTRFORMAT, t)
-        filename = time_str+'_'+str(path.stem)+'.png'
-        screenshot.save(str(path.parent)+'/'+filename, format='PNG')
+        if self.title is not None:
+            path = Path(self.title)
+            # add a timestamp here
+            t = time.localtime()
+            time_str = time.strftime(TIMESTRFORMAT, t)
+            filename = time_str+'_'+str(path.stem)+'.png'
+            screenshot.save(str(path.parent)+'/'+filename, format='PNG')
+            return
+
+        logger.error("Could not find the path of the figuer. Figure has not been saved")
 
     # TODO: Allow for the option to choose filetypes and the name/directory
 


### PR DESCRIPTION
Found bug when trying to save a histogram plot. 

Previously the title for the file created when saving the plot was being gathered from the title meta value in the current data being displayed. The histogram node however, was not saving the title meta value when processing the data, leading into the saving button not working when that happened.

Added a title attribute to the AutoPlot class that updates every time the _plotData method gets called if the title meta value is present in the data that is being processed at the moment. 

If for some reason it still cannot find the title, an error will be displayed indicating to the user that it could not find the path instead of crashing.