### PR TITLE
Mypy: Only ignore missing imports for packages known to not have types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ build-backend = 'setuptools.build_meta'
 
 [tool.mypy]
 strict_optional = true
-ignore_missing_imports = true
 show_column_numbers = true
 warn_unused_ignores = true
 warn_unused_configs = true
@@ -26,6 +25,16 @@ module = [
     "plottr.apps.ui.Monitr_UI",
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "h5py",
+    "lmfit",
+    "matplotlib.*",
+    "pyqtgraph.*",
+    "xhistogram.*",
+]
+ignore_missing_imports = true
 
 [tool.versioningit]
 default-version = "0.0"


### PR DESCRIPTION
This will statically catch typos in imports for all other modules

To be merged after #326