### PR TITLE
Improve plotting when metadata setpoints are obviously wrong.

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1029,10 +1029,13 @@ class MeshgridDataDict(DataDictBase):
             if 'axes' in v:
                 for axis_num, na in enumerate(v['axes']):
                     # check that the data of the axes matches its use
-                    max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
-                    if max_step_along_axes == 0:
-                        msg += (f"Malformed data: {na} is expected to be {axis_num}th "
-                                 "axis but has no variation along that axis.\n")
+                    # if data present
+                    axis_data = data_items[na]['values']
+                    if axis_data.size > 0:
+                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
+                        if max_step_along_axes == 0:
+                            msg += (f"Malformed data: {na} is expected to be {axis_num}th "
+                                     "axis but has no variation along that axis.\n")
 
             if msg != '\n':
                 raise ValueError(msg)

--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1010,7 +1010,10 @@ class MeshgridDataDict(DataDictBase):
 
         shp = None
         shpsrc = ''
-        for n, v in self.data_items():
+
+        data_items = dict(self.data_items())
+
+        for n, v in data_items.items():
             if type(v['values']) not in [np.ndarray, np.ma.core.MaskedArray]:
                 self[n]['values'] = np.array(v['values'])
 
@@ -1022,6 +1025,14 @@ class MeshgridDataDict(DataDictBase):
                     msg += f" * shapes need to match, but '{n}' has"
                     msg += f" {v['values'].shape}, "
                     msg += f"and '{shpsrc}' has {shp}.\n"
+
+            if 'axes' in v:
+                for axis_num, na in enumerate(v['axes']):
+                    # check that the data of the axes matches its use
+                    max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
+                    if max_step_along_axes == 0:
+                        msg += (f"Malformed data: {na} is expected to be {axis_num}th "
+                                 "axis but has no variation along that axis.\n")
 
             if msg != '\n':
                 raise ValueError(msg)
@@ -1087,7 +1098,7 @@ def guess_shape_from_datadict(data: DataDict) -> \
 
 def datadict_to_meshgrid(data: DataDict,
                          target_shape: Union[Tuple[int, ...], None] = None,
-                         inner_axis_order: Union[None, List[str]] = None,
+                         inner_axis_order: Union[None, Sequence[str]] = None,
                          use_existing_shape: bool = False) \
         -> MeshgridDataDict:
     """

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -3,7 +3,6 @@ grid.py
 
 A node and widget for placing data onto a grid (or not).
 """
-
 from enum import Enum, unique
 
 from typing import Tuple, Dict, Any, List, Optional, Sequence, cast
@@ -490,9 +489,19 @@ class DataGridder(Node[DataGridderNodeWidget]):
                         inner_axis_order=order,
                     )
                 elif method is GridOption.metadataShape:
-                    dout = dd.datadict_to_meshgrid(
-                        data, use_existing_shape=True
-                    )
+                    try:
+                        dout = dd.datadict_to_meshgrid(
+                            data, use_existing_shape=True
+                        )
+                    except ValueError as err:
+                        if "Malformed data" in str(err):
+                            self.node_logger.warning(
+                                "Shape/Setpoint order does"
+                                " not match data. Falling back to guessing shape"
+                                )
+                            dout = dd.datadict_to_meshgrid(data)
+                        else:
+                            raise err
             except GriddingError:
                 dout = data.expand()
                 self.node_logger.info("data could not be gridded. Falling back "

--- a/test/pytest/test_gridder.py
+++ b/test/pytest/test_gridder.py
@@ -93,12 +93,9 @@ def test_set_grid_with_order(qtbot):
     assert fc.outputValues()['dataOut']['vals']['axes'] == ['y', 'z', 'x']
 
     # finally, specify manually. omitting inner shape doesn't work
+    # but will be caught by validation (and no data returned)
     node.grid = GridOption.specifyShape, dict(shape=(5, 2, 5))
-    assert fc.outputValues()['dataOut'].data_vals('vals').shape == (5,2,5)
-    assert not num.arrays_equal(
-        fc.outputValues()['dataOut'].data_vals('vals'),
-        vv.transpose((1,2,0)),
-    )
+    assert fc.outputValues()['dataOut'] is None
 
     # but using the right inner axis order should do it
     node.grid = GridOption.specifyShape, dict(order=['x', 'y', 'z'],


### PR DESCRIPTION
It may happen that the user has created a dataset where the setpoints are inverted in the metadata leading to incorrect plotting. Here we handle the most obvious case where the setpoints are identical along the axis of interest by falling back to guessing the shape in such cases. 