### PR TITLE
The FileOpener now creates a lock file.

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -124,10 +124,7 @@ def _data_file_path(file: Union[str, Path], init_directory: bool = False) -> Pat
     """Get the full filepath of the data file.
     If `init_directory` is True, then create the parent directory."""
 
-    if isinstance(file, str):
-        path = Path(file)
-    else:
-        path = file
+    path = Path(file)
 
     if path.suffix != f'.{DATAFILEXT}':
         path = Path(path.parent, path.stem + f'.{DATAFILEXT}')
@@ -137,7 +134,7 @@ def _data_file_path(file: Union[str, Path], init_directory: bool = False) -> Pat
 
 # TODO: Check if the linking of class in the docstring is working.
 def datadict_to_hdf5(datadict: DataDict,
-                     path: str,
+                     path: Union[str, Path],
                      groupname: str = 'data',
                      append_mode: AppendMode = AppendMode.new,
                      file_timeout: Optional[float] = None) -> None:
@@ -230,7 +227,7 @@ def init_file(f: h5py.File,
         f.flush()
 
 
-def datadict_from_hdf5(path: str,
+def datadict_from_hdf5(path: Union[str, Path],
                        groupname: str = 'data',
                        startidx: Union[int, None] = None,
                        stopidx: Union[int, None] = None,
@@ -310,7 +307,7 @@ def datadict_from_hdf5(path: str,
     return dd
 
 
-def all_datadicts_from_hdf5(path: str, file_timeout: Optional[float] = None, **kwargs: Any) -> Dict[str, Any]:
+def all_datadicts_from_hdf5(path: Union[str, Path], file_timeout: Optional[float] = None, **kwargs: Any) -> Dict[str, Any]:
     """
     Loads all the DataDicts contained on a single HDF5 file. Returns a dictionary with the group names as keys and
     the DataDicts as the values of that key.
@@ -337,11 +334,11 @@ def all_datadicts_from_hdf5(path: str, file_timeout: Optional[float] = None, **k
 class FileOpener:
     """Context manager for opening files while respecting file system locks."""
 
-    def __init__(self, path: Path,
+    def __init__(self, path: Union[Path, str],
                  mode: str = 'r',
                  timeout: Optional[float] = None,
                  test_delay: float = 0.1):
-        self.path = path
+        self.path = Path(path)
         self.lock_path = path.parent.joinpath("~" + str(path.stem) + '.lock')
         if mode not in ['r', 'w', 'w-', 'a']:
             raise ValueError("Only 'r', 'w', 'w-', 'a' modes are supported.")

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -339,7 +339,7 @@ class FileOpener:
                  timeout: Optional[float] = None,
                  test_delay: float = 0.1):
         self.path = Path(path)
-        self.lock_path = path.parent.joinpath("~" + str(path.stem) + '.lock')
+        self.lock_path = self.path.parent.joinpath("~" + str(self.path.stem) + '.lock')
         if mode not in ['r', 'w', 'w-', 'a']:
             raise ValueError("Only 'r', 'w', 'w-', 'a' modes are supported.")
         self.mode = mode

--- a/test/pytest/test_ddh5.py
+++ b/test/pytest/test_ddh5.py
@@ -45,6 +45,21 @@ def _clean_from_file(datafromfile):
 
     return datafromfile
 
+# Test the FileOpener.
+
+
+def test_file_lock_creation_and_deletion():
+    lock_path = FILEPATH.parent.joinpath("~" + str(FILEPATH.stem) + '.lock')
+    try:
+        with dds.FileOpener(FILEPATH, 'a') as f:
+            assert lock_path.is_file()
+            raise RuntimeError('crashing on purpose')
+    except RuntimeError:
+        pass
+    assert not lock_path.is_file()
+
+    FILEPATH.unlink()
+
 
 def test_basic_storage_and_retrieval():
     x = np.arange(3)

--- a/test/pytest/test_ddh5.py
+++ b/test/pytest/test_ddh5.py
@@ -39,6 +39,10 @@ def _clean_from_file(datafromfile):
     except KeyError:
         pass
 
+    for axis, data in datafromfile.data_items():
+        if "label" in data:
+            datafromfile[axis].pop("label")
+
     return datafromfile
 
 
@@ -216,7 +220,7 @@ def test_writer_with_large_data():
     dataset_from_file = dds.datadict_from_hdf5(writer.filepath)
     assert(_clean_from_file(dataset_from_file) == ref_dataset)
 
-    rmtree('./TESTDATA')
+    rmtree(str(Path(writer.filepath).parent))
 
 
 def test_concurrent_write_and_read():
@@ -238,4 +242,4 @@ def test_concurrent_write_and_read():
     dataset_from_file = dds.datadict_from_hdf5(writer.filepath)
     assert(_clean_from_file(dataset_from_file) == ref_dataset)
 
-    rmtree('./TESTDATA')
+    rmtree(str(Path(writer.filepath).parent))


### PR DESCRIPTION
When entering the FileOpener context manager, a file lock is now created with the following filename structure " ~<file_name>.lock". All of the functions in the datadict_storage.py module use the FileOpener internally.

All of the functions that use the FileOpener now also have a new argument file_timeout to pass a different amount of time for the timeout of a lock file. This is because in my testing when files start to get big, sometimes a writer or reader takes longer than the timeout time, making the program crash.

I have also created a simple test that tests if the FileOpener creates the lock file, crashes program and checks if the lock file is still being deleted afterwards. I wasn't sure what else add to the unit tests.

As a little convenience bonus, all of the storage functions now accept both str and Path instead of just str and converting them to Path in the function.