### PR TITLE
Launch a new app using the same python executable

### DIFF
--- a/plottr/apps/appmanager.py
+++ b/plottr/apps/appmanager.py
@@ -13,6 +13,7 @@ app processes. An app can be launched using the launchApp function.
     will result in the app not opening without an error warning.
 """
 
+import sys
 import zmq
 from pathlib import Path
 from typing import Dict, Union, Any, Callable, Tuple, Optional
@@ -352,7 +353,7 @@ class AppManager(QtWidgets.QWidget):
 
             fullArgs = [str(Path(plottrPath).joinpath('apps', 'apprunner.py')), str(port), module, func] + list(args)
             process = QtCore.QProcess()
-            process.start('python', fullArgs)
+            process.start(sys.executable, fullArgs)
             process.waitForStarted(100)
             socket = self.context.socket(zmq.REQ)
             socket.connect(f'tcp://{self.address}:{str(port)}')


### PR DESCRIPTION
Currently, the AppManager launches a new process using the command `python`.
However, if plottr-monitor is running inside a virtual environment, the new process should be launched using the python executable specific to the environment.
With this fix, a new process is launched using `sys.executable`, which contains the path to the current python executable.