### PR TITLE
Bugfix: guessing the grid raises an exception when one of the dimensions is 1

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1044,7 +1044,7 @@ class MeshgridDataDict(DataDictBase):
                     # if data present
                     axis_data = data_items[na]['values']
                     if axis_data.size > 0:
-                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
+                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)), initial=0)
                         if max_step_along_axes == 0:
                             msg += (f"Malformed data: {na} is expected to be {axis_num}th "
                                      "axis but has no variation along that axis.\n")

--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1043,8 +1043,8 @@ class MeshgridDataDict(DataDictBase):
                     # check that the data of the axes matches its use
                     # if data present
                     axis_data = data_items[na]['values']
-                    if axis_data.size > 0:
-                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)), initial=0)
+                    if data_items[na]['values'].shape[axis_num] > 1:
+                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
                         if max_step_along_axes == 0:
                             msg += (f"Malformed data: {na} is expected to be {axis_num}th "
                                      "axis but has no variation along that axis.\n")

--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1043,8 +1043,8 @@ class MeshgridDataDict(DataDictBase):
                     # check that the data of the axes matches its use
                     # if data present
                     axis_data = data_items[na]['values']
-                    if data_items[na]['values'].shape[axis_num] > 1:
-                        max_step_along_axes = np.max(np.abs(np.diff(data_items[na]['values'],axis=axis_num)))
+                    if axis_data.ndim > axis_num and axis_data.shape[axis_num] > 1:
+                        max_step_along_axes = np.max(np.abs(np.diff(axis_data, axis=axis_num)))
                         if max_step_along_axes == 0:
                             msg += (f"Malformed data: {na} is expected to be {axis_num}th "
                                      "axis but has no variation along that axis.\n")


### PR DESCRIPTION
Currently, plottr cannot plot a data with more than two axes if one of the dimensions is 1.
This is because MeshGridDataDict.validate() trys to take the max of an empty array and raises an exception.
This pull request fixes this bug.