### PR TITLE
Bugfix: Font family 'Helvetica' not found

### DIFF
--- a/plottr/config/plottrcfg_main.py
+++ b/plottr/config/plottrcfg_main.py
@@ -13,7 +13,7 @@ config = {
         'figure.dpi': 150,
         'figure.figsize': (4.5, 3),
         'font.size': 6,
-        'font.family': ['Helvetica', 'Arial', 'DejaVu Sans', 'Bitstream Vera Sans'],
+        'font.sans-serif': ['Helvetica', 'Arial', 'DejaVu Sans', 'Bitstream Vera Sans'],
         'grid.linewidth': 0.5,
         'grid.linestyle': '--',
         'image.cmap': 'magma',


### PR DESCRIPTION
Currently, messages like `findfont: Font family 'Helvetica' not found` are printed tens of times whenever a plot window is opened.
I think this is due to a typo in the font configuration for matplotlib, which I have fixed here.