### PR TITLE
Generate UUID only once per DDH5Writer

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -602,6 +602,7 @@ class DDH5Writer(object):
 
         self.datadict.add_meta('dataset.name', name)
         self.file_timeout = file_timeout
+        self.uuid = uuid.uuid1()
 
     def __enter__(self) -> "DDH5Writer":
         if self.filepath is None:
@@ -636,7 +637,7 @@ class DDH5Writer(object):
 
         :returns: The folder path.
         """
-        ID = str(uuid.uuid1()).split('-')[0]
+        ID = str(self.uuid).split('-')[0]
         parent = f"{datetime.datetime.now().replace(microsecond=0).isoformat().replace(':', '')}_{ID}"
         if self.name:
             parent += f'-{self.name}'


### PR DESCRIPTION
Currently, DDH5Writer.data_folder() returns a different path every time it is called because the UUID is re-generated each time.
With this bugfix, the UUID is generated only once when a DDH5Writer is instantiated.