### PR TITLE
Feature for monitr: choose backend for each plot

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -377,11 +377,11 @@ def autoplotDDH5App(*args: Any) -> Tuple[Flowchart, AutoPlotMainWindow]:
     filepath = args[0][0]
     groupname = args[0][1]
     if len(args[0]) > 2 and args[0][2] == "matplotlib":
-        autoplotDDH5(filepath, groupname, MPLAutoPlot)
+        return autoplotDDH5(filepath, groupname, MPLAutoPlot)
     elif len(args[0]) > 2 and args[0][2] == "pyqtgraph":
-        autoplotDDH5(filepath, groupname, PGAutoPlot)
+        return autoplotDDH5(filepath, groupname, PGAutoPlot)
     else:
-        autoplotDDH5(filepath, groupname)  # use default backend
+        return autoplotDDH5(filepath, groupname)  # use default backend
 
 
 def main(f: str, g: str) -> int:

--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -377,13 +377,11 @@ def autoplotDDH5App(*args: Any) -> Tuple[Flowchart, AutoPlotMainWindow]:
     filepath = args[0][0]
     groupname = args[0][1]
     if len(args[0]) > 2 and args[0][2] == "matplotlib":
-        plotWidgetClass = MPLAutoPlot
+        autoplotDDH5(filepath, groupname, MPLAutoPlot)
     elif len(args[0]) > 2 and args[0][2] == "pyqtgraph":
-        plotWidgetClass = PGAutoPlot
+        autoplotDDH5(filepath, groupname, PGAutoPlot)
     else:
-        plotWidgetClass = None  # use default backend
-
-    return autoplotDDH5(filepath, groupname, plotWidgetClass)
+        autoplotDDH5(filepath, groupname)  # use default backend
 
 
 def main(f: str, g: str) -> int:

--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -25,6 +25,7 @@ from ..node.tools import linearFlowchart
 from ..node.node import Node
 from ..node.histogram import Histogrammer
 from ..plot import PlotNode, makeFlowchartWithPlot, PlotWidget
+from ..plot.mpl.autoplot import AutoPlot as MPLAutoPlot
 from ..plot.pyqtgraph.autoplot import AutoPlot as PGAutoPlot
 from ..utils.misc import unwrap_optional
 
@@ -335,7 +336,9 @@ def autoplotQcodesDataset(log: bool = False,
     return fc, win
 
 
-def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
+def autoplotDDH5(filepath: str = '',
+                 groupname: str = 'data',
+                 plotWidgetClass: Optional[Type[PlotWidget]] = None) \
         -> Tuple[Flowchart, AutoPlotMainWindow]:
 
     fc = linearFlowchart(
@@ -359,7 +362,8 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
     win = AutoPlotMainWindow(fc, loaderName='Data loader',
                              widgetOptions=widgetOptions,
                              monitor=True,
-                             monitorInterval=0.0)
+                             monitorInterval=0.0,
+                             plotWidgetClass=plotWidgetClass)
     win.show()
 
     fc.nodes()['Data loader'].filepath = filepath
@@ -372,8 +376,14 @@ def autoplotDDH5(filepath: str = '', groupname: str = 'data') \
 def autoplotDDH5App(*args: Any) -> Tuple[Flowchart, AutoPlotMainWindow]:
     filepath = args[0][0]
     groupname = args[0][1]
+    if len(args[0]) > 2 and args[0][2] == "matplotlib":
+        plotWidgetClass = MPLAutoPlot
+    elif len(args[0]) > 2 and args[0][2] == "pyqtgraph":
+        plotWidgetClass = PGAutoPlot
+    else:
+        plotWidgetClass = None  # use default backend
 
-    return autoplotDDH5(filepath, groupname)
+    return autoplotDDH5(filepath, groupname, plotWidgetClass)
 
 
 def main(f: str, g: str) -> int:

--- a/plottr/apps/monitr.py
+++ b/plottr/apps/monitr.py
@@ -1886,7 +1886,8 @@ class DataTreeWidget(QtWidgets.QTreeWidget):
     # Signal(Path) -- Emitted when the user selects the plot option in the popup menu.
     #: Arguments:
     #:   - The path of the ddh5 with the data for the requested plot.
-    plot_requested = Signal(Path)
+    #:   - The name of the selected backend
+    plot_requested = Signal(Path, str)
 
     # incoming_data: Dict[str, Union[Path, str, DataDict]]
     def __init__(self, paths: List[Path], names: List[str], data: DataDict, *args: Any, **kwargs: Any):
@@ -1902,10 +1903,13 @@ class DataTreeWidget(QtWidgets.QTreeWidget):
         self.data = data
 
         # Popup menu.
-        self.plot_popup_action = QtWidgets.QAction('Plot')
+        self.plot_matplotlib_action = QtWidgets.QAction(f'Plot (matplotlib)')
+        self.plot_matplotlib_action.triggered.connect(self.emit_plot_requested_signal)
+        self.plot_pyqtgraph_action = QtWidgets.QAction(f'Plot (pyqtgraph)')
+        self.plot_pyqtgraph_action.triggered.connect(self.emit_plot_requested_signal)
         self.popup_menu = QtWidgets.QMenu(self)
-
-        self.plot_popup_action.triggered.connect(self.emit_plot_requested_signal)
+        self.popup_menu.addAction(self.plot_matplotlib_action)
+        self.popup_menu.addAction(self.plot_pyqtgraph_action)
 
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.on_context_menu_requested)
@@ -1954,19 +1958,20 @@ class DataTreeWidget(QtWidgets.QTreeWidget):
         parent_item = item.parent()
         # Check that the item is in fact a top level item and open the popup menu
         if item is not None and parent_item is None:
-            self.popup_menu.addAction(self.plot_popup_action)
             self.popup_menu.exec_(self.mapToGlobal(pos))
-            self.popup_menu.removeAction(self.plot_popup_action)
 
     @Slot()
     def emit_plot_requested_signal(self) -> None:
         """
         Emits the signal when the user selects the plot option in the popup menu. The signal is emitted with the Path of
-        the current selected item as an argument.
+        the current selected item and the selected backend as arguments.
         """
         current_item = self.currentItem()
         assert isinstance(current_item, DataTreeWidgetItem)
-        self.plot_requested.emit(current_item.path)
+        if self.sender() == self.plot_matplotlib_action:
+            self.plot_requested.emit(current_item.path, 'matplotlib')
+        elif self.sender() == self.plot_pyqtgraph_action:
+            self.plot_requested.emit(current_item.path, 'pyqtgraph')
 
     def sizeHint(self) -> QtCore.QSize:
         height = 2 * self.frameWidth()  # border around tree
@@ -3119,8 +3124,8 @@ class Monitr(QtWidgets.QMainWindow):
 
         self.right_side_layout.addWidget(self.data_window)
 
-    @Slot(Path)
-    def on_plot_data(self, path: Path) -> None:
+    @Slot(Path, str)
+    def on_plot_data(self, path: Path, backend: str) -> None:
         """
         Gets called when the user clicks plot on the context menu of the data viewer. Orders the app manager to open
         a new autoplot window.
@@ -3128,7 +3133,7 @@ class Monitr(QtWidgets.QMainWindow):
         :param path: The path of the ddh5 file that should be displayed.
         :return:
         """
-        self.app_manager.launchApp(self.current_app_id, AUTOPLOTMODULE, AUTOPLOTFUNC, str(path), 'data')
+        self.app_manager.launchApp(self.current_app_id, AUTOPLOTMODULE, AUTOPLOTFUNC, str(path), 'data', backend)
         self.current_app_id += 1
 
     def add_text_input(self, path: Path) -> None:

--- a/plottr/apps/monitr.py
+++ b/plottr/apps/monitr.py
@@ -2785,8 +2785,9 @@ class Monitr(QtWidgets.QMainWindow):
         menu = menu_bar.addMenu("Backend")
         self.backend_group = QtWidgets.QActionGroup(menu)
         for backend, plotWidgetClass in [("matplotlib", MPLAutoPlot), ("pyqtgraph", PGAutoPlot)]:
-            checked = getcfg('main', 'default-plotwidget') == plotWidgetClass
-            action = QtWidgets.QAction(backend, checkable=True, checked=checked)
+            action = QtWidgets.QAction(backend)
+            action.setCheckable(True)
+            action.setChecked(getcfg('main', 'default-plotwidget') == plotWidgetClass)
             self.backend_group.addAction(action)
             menu.addAction(action)
 


### PR DESCRIPTION
Currently, when a data in the right-side window of monitr is right-clicked, a context menu with one entry "Plot" appears.
With this pull request, there will be two entries "Plot (matplotlib)" and "Plot (pyqtgraph)", and one will be able to choose the backend for each plot.