### PR TITLE
Add convenience methods

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -12,6 +12,8 @@ import logging
 import time
 import datetime
 import uuid
+import json
+import shutil
 from enum import Enum
 from typing import Any, Union, Optional, Dict, Type, Collection
 from types import TracebackType
@@ -20,6 +22,7 @@ from pathlib import Path
 import numpy as np
 import h5py
 
+from qcodes.utils import NumpyJSONEncoder
 from plottr import QtGui, Signal, Slot, QtWidgets, QtCore
 
 from ..node import (
@@ -687,3 +690,26 @@ class DDH5Writer(object):
             with FileOpener(self.filepath, 'a', timeout=self.file_timeout) as f:
                 add_cur_time_attr(f, name='last_change')
                 add_cur_time_attr(f[self.groupname], name='last_change')
+
+
+    # convenience methods for saving things in the same directory as the ddh5 file
+
+    def add_tag(self, tags: Union[str, Collection[str]]):
+        if isinstance(tags, str):
+            tags = [tags]
+        for tag in tags:
+            open(self.filepath.parent / f"{tag}.tag", "x").close()
+
+    def backup_file(self, paths: Union[str, Collection[str]]):
+        if isinstance(paths, str):
+            paths = [paths]
+        for path in paths:
+            shutil.copy(path, self.filepath.parent)
+
+    def save_text(self, name: str, text: str):
+        with open(self.filepath.parent / name, "x") as f:
+            f.write(text)
+
+    def save_dict(self, name: str, d: dict):
+        with open(self.filepath.parent / name, "x") as f:
+            json.dump(d, f, indent=4, ensure_ascii=False, cls=NumpyJSONEncoder)

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -694,22 +694,26 @@ class DDH5Writer(object):
 
     # convenience methods for saving things in the same directory as the ddh5 file
 
-    def add_tag(self, tags: Union[str, Collection[str]]):
+    def add_tag(self, tags: Union[str, Collection[str]]) -> None:
+        assert self.filepath is not None
         if isinstance(tags, str):
             tags = [tags]
         for tag in tags:
             open(self.filepath.parent / f"{tag}.tag", "x").close()
 
-    def backup_file(self, paths: Union[str, Collection[str]]):
+    def backup_file(self, paths: Union[str, Collection[str]]) -> None:
+        assert self.filepath is not None
         if isinstance(paths, str):
             paths = [paths]
         for path in paths:
             shutil.copy(path, self.filepath.parent)
 
-    def save_text(self, name: str, text: str):
+    def save_text(self, name: str, text: str) -> None:
+        assert self.filepath is not None
         with open(self.filepath.parent / name, "x") as f:
             f.write(text)
 
-    def save_dict(self, name: str, d: dict):
+    def save_dict(self, name: str, d: dict) -> None:
+        assert self.filepath is not None
         with open(self.filepath.parent / name, "x") as f:
             json.dump(d, f, indent=4, ensure_ascii=False, cls=NumpyJSONEncoder)


### PR DESCRIPTION
Added convenience methods `add_tag`, `backup_file`, `save_text`, and `save_dict` to `DDH5Writer`.
They enable us to save things in the same directory as the ddh5 file.
Usage example:
```
import qcodes as qc
from plottr.data.datadict_storage import DataDict, DDH5Writer

station = qc.Station()
data = DataDict(
    time=dict(unit="s"),
    voltage=dict(unit="V", axes=["time"]),
)

with DDH5Writer(data) as writer:
    writer.add_tag(["tag1", "tag2"])
    writer.backup_file(__file__)
    writer.save_text("note.md", "some note")
    writer.save_dict("station_snapshot.json", station.snapshot())
    writer.add_data(
        time=[1, 2, 3],
        voltage=[4, 5, 6],
    )
```