### PR TITLE
Feature for monitr: show whether a measurement is complete or was interrupted

### DIFF
--- a/plottr/apps/monitr.py
+++ b/plottr/apps/monitr.py
@@ -32,7 +32,7 @@ from ..utils.misc import unwrap_optional
 from ..apps.watchdog_classes import WatcherClient
 from ..gui.widgets import Collapsible
 from .json_viewer import JsonModel, JsonTreeView
-from ..icons import get_starIcon as get_star_icon, get_trashIcon as get_trash_icon, get_imageIcon as get_img_icon, get_jsonIcon as get_json_icon, get_mdIcon as get_md_icon
+from ..icons import get_starIcon as get_star_icon, get_trashIcon as get_trash_icon, get_completeIcon as get_complete_icon, get_interruptedIcon as get_interrupted_icon, get_imageIcon as get_img_icon, get_jsonIcon as get_json_icon, get_mdIcon as get_md_icon
 from .appmanager import AppManager
 
 TIMESTRFORMAT = "%Y-%m-%dT%H%M%S"
@@ -166,11 +166,14 @@ class Item(QtGui.QStandardItem):
         self.tags_widget = ItemTagLabel(self.tags)
         self.star = False
         self.trash = False
+        self.complete = False
+        self.interrupted = False
         self.scroll_height = 0
         self.show = True
         if files is not None:
             self.files.update(files)
             self.tags = [file.stem for file, file_type in self.files.items() if file_type == ContentType.tag]
+
             if '__star__' in self.tags and '__trash__' in self.tags:
                 star_path = self.path.joinpath('__star__.tag')
                 trash_path = self.path.joinpath('__trash__.tag')
@@ -187,6 +190,24 @@ class Item(QtGui.QStandardItem):
             elif '__trash__' in self.tags:
                 self.trash = True
                 self.tags.remove('__trash__')
+
+            if '__complete__' in self.tags and '__interrupted__' in self.tags:
+                complete_path = self.path.joinpath('__complete__.tag')
+                interrupted_path = self.path.joinpath('__interrupted__.tag')
+                if complete_path.is_file() and interrupted_path.is_file():
+                    LOGGER.error(
+                        f'The folder: {self.path} contains both the complete and interrupted tag. Both tags will be deleted.')
+                    complete_path.unlink()
+                    interrupted_path.unlink()
+                    self.tags.remove('__complete__')
+                    self.tags.remove('__interrupted__')
+            elif '__complete__' in self.tags:
+                self.complete = True
+                self.tags.remove('__complete__')
+            elif '__interrupted__' in self.tags:
+                self.interrupted = True
+                self.tags.remove('__interrupted__')
+
             self.tags_widget = ItemTagLabel(self.tags)
 
         self.setText(str(self.path.name))
@@ -213,7 +234,7 @@ class Item(QtGui.QStandardItem):
                     error_msg = QtWidgets.QMessageBox()
                     error_msg.setText(f'Folder is already trash. Please do not add both __trash__ and __star__ tags in the same folder. '
                                       f' \n {path} was deleted ')
-                    error_msg.setWindowTitle(f'Deleting __trash__.tag')
+                    error_msg.setWindowTitle(f'Deleting __star__.tag')
                     error_msg.exec_()
                     return
                 else:
@@ -228,11 +249,42 @@ class Item(QtGui.QStandardItem):
                     error_msg.setText(
                         f'Folder is already star. Please do not add both __trash__ and __star__ tags in the same folder. '
                         f' \n {path} was deleted ')
-                    error_msg.setWindowTitle(f'Deleting __star__.tag')
+                    error_msg.setWindowTitle(f'Deleting __trash__.tag')
                     error_msg.exec_()
                     return
                 else:
                     self.trash = True
+
+            elif path.name == '__complete__.tag':
+                # Check if the item is already tagged as interrupted.
+                interrupted_path = path.parent.joinpath('__interrupted__.tag')
+                if interrupted_path.is_file():
+                    path.unlink()
+                    error_msg = QtWidgets.QMessageBox()
+                    error_msg.setText(
+                        f'Folder is already tagged as interrupted. Please do not add both __complete__ and __interrupted__ tags in the same folder.\n'
+                        f'{path} was deleted.')
+                    error_msg.setWindowTitle(f'Deleting __complete__.tag')
+                    error_msg.exec_()
+                    return
+                else:
+                    self.complete = True
+
+            elif path.name == '__interrupted__.tag':
+                # Check if the item is already tagged as complete.
+                complete_path = path.parent.joinpath('__complete__.tag')
+                if complete_path.is_file():
+                    path.unlink()
+                    error_msg = QtWidgets.QMessageBox()
+                    error_msg.setText(
+                        f'Folder is already tagged as complete. Please do not add both __complete__ and __interrupted__ tags in the same folder.\n'
+                        f'{path} was deleted.')
+                    error_msg.setWindowTitle(f'Deleting __interrupted__.tag')
+                    error_msg.exec_()
+                    return
+                else:
+                    self.interrupted = True
+
             else:
                 self.tags.append(path.stem)
                 self.tags_widget.add_tag(path.stem)
@@ -262,6 +314,10 @@ class Item(QtGui.QStandardItem):
                 self.star = False
             elif path.name == '__trash__.tag':
                 self.trash = False
+            elif path.name == '__complete__.tag':
+                self.complete = False
+            elif path.name == '__interrupted__.tag':
+                self.interrupted = False
 
             model.item_files_changed(self)
 
@@ -494,6 +550,10 @@ class FileModel(QtGui.QStandardItemModel):
             item.setIcon(get_star_icon())
         elif item.trash:
             item.setIcon(get_trash_icon())
+        elif item.complete:
+            item.setIcon(get_complete_icon())
+        elif item.interrupted:
+            item.setIcon(get_interrupted_icon())
         else:
             item.setIcon(QtGui.QIcon())
 
@@ -889,6 +949,10 @@ class FileModel(QtGui.QStandardItemModel):
             item.setIcon(get_star_icon())
         elif item.trash:
             item.setIcon(get_trash_icon())
+        elif item.complete:
+            item.setIcon(get_complete_icon())
+        elif item.interrupted:
+            item.setIcon(get_interrupted_icon())
         else:
             item.setIcon(QtGui.QIcon())
 

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -628,6 +628,12 @@ class DDH5Writer(object):
         assert self.filepath is not None
         with FileOpener(self.filepath, 'a', timeout=self.file_timeout) as f:
             add_cur_time_attr(f[self.groupname], name='close')
+        if exc_type is None:
+            # exiting because the measurement is complete
+            self.add_tag('__complete__')
+        else:
+            # exiting because of an exception
+            self.add_tag('__interrupted__')
 
     def data_folder(self) -> Path:
         """Return the folder, relative to the data root path, in which data will

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -12,6 +12,8 @@ import logging
 import time
 import datetime
 import uuid
+import json
+import shutil
 from enum import Enum
 from typing import Any, Union, Optional, Dict, Type, Collection
 from types import TracebackType
@@ -20,6 +22,7 @@ from pathlib import Path
 import numpy as np
 import h5py
 
+from qcodes.utils import NumpyJSONEncoder
 from plottr import QtGui, Signal, Slot, QtWidgets, QtCore
 
 from ..node import (
@@ -687,3 +690,26 @@ class DDH5Writer(object):
             with FileOpener(self.filepath, 'a', timeout=self.file_timeout) as f:
                 add_cur_time_attr(f, name='last_change')
                 add_cur_time_attr(f[self.groupname], name='last_change')
+
+
+    # convenience methods for saving things in the same directory as the ddh5 file
+
+    def add_tag(self, tags: Union[str, Collection[str]]):
+        if isinstance(tags, str):
+            tags = [tags]
+        for tag in tags:
+            open(self.filepath.parent / f"{tag}.tag", "x").close()
+
+    def backup_file(self, paths: Union[str, Collection[str]]):
+        if isinstance(paths, str):
+            paths = [paths]
+        for path in paths:
+            shutil.copy(path, self.filepath.parent)
+
+    def save_text(self, name: str, text: str):
+        with open(self.filepath.parent / name, "x") as f:
+            f.write(text)
+
+    def save_dict(self, name: str, d: dict):
+        with open(self.filepath.parent / name, "x") as f:
+            json.dump(d, f, indent=4, ensure_ascii=False, cls=NumpyJSONEncoder)

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -694,22 +694,26 @@ class DDH5Writer(object):
 
     # convenience methods for saving things in the same directory as the ddh5 file
 
-    def add_tag(self, tags: Union[str, Collection[str]]):
+    def add_tag(self, tags: Union[str, Collection[str]]) -> None:
+        assert self.filepath is not None
         if isinstance(tags, str):
             tags = [tags]
         for tag in tags:
             open(self.filepath.parent / f"{tag}.tag", "x").close()
 
-    def backup_file(self, paths: Union[str, Collection[str]]):
+    def backup_file(self, paths: Union[str, Collection[str]]) -> None:
+        assert self.filepath is not None
         if isinstance(paths, str):
             paths = [paths]
         for path in paths:
             shutil.copy(path, self.filepath.parent)
 
-    def save_text(self, name: str, text: str):
+    def save_text(self, name: str, text: str) -> None:
+        assert self.filepath is not None
         with open(self.filepath.parent / name, "x") as f:
             f.write(text)
 
-    def save_dict(self, name: str, d: dict):
+    def save_dict(self, name: str, d: dict) -> None:
+        assert self.filepath is not None
         with open(self.filepath.parent / name, "x") as f:
             json.dump(d, f, indent=4, ensure_ascii=False, cls=NumpyJSONEncoder)

--- a/plottr/icons.py
+++ b/plottr/icons.py
@@ -94,6 +94,23 @@ def get_starIcon() -> QtGui.QIcon:
     return starIcon
 
 
+def get_completeIcon() -> QtGui.QIcon:
+    """
+    Icon taken from: https://glyphs.fyi/
+    """
+    completeIcon = QtGui.QIcon(
+        os.path.join(gfxPath, "complete.svg")
+    )
+    return completeIcon
+
+
+def get_interruptedIcon() -> QtGui.QIcon:
+    interruptedIcon = QtGui.QIcon(
+        os.path.join(gfxPath, "interrupted.svg")
+    )
+    return interruptedIcon
+
+
 def get_imageIcon() -> QtGui.QIcon:
     """
     Icon taken from: https://www.svgrepo.com/collection/file-type-collection/

--- a/plottr/resource/gfx/complete.svg
+++ b/plottr/resource/gfx/complete.svg
@@ -1,0 +1,3 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14.1214 40.092L29.6777 55.6484C30.4588 56.4294 31.7251 56.4294 32.5062 55.6484L65.0331 23.1214" stroke="#219653" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/plottr/resource/gfx/interrupted.svg
+++ b/plottr/resource/gfx/interrupted.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="80"
+   height="80"
+   viewBox="0 0 80 80"
+   fill="none"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="interrupted.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="10.2"
+     inkscape:cx="32.745098"
+     inkscape:cy="40.147059"
+     inkscape:window-width="1920"
+     inkscape:window-height="996"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7117"
+       units="px"
+       spacingx="1"
+       spacingy="1" />
+  </sodipodi:namedview>
+  <circle
+     style="fill:none;stroke:#ff0000;stroke-width:4;stroke-dasharray:none"
+     id="path7329"
+     cx="40"
+     cy="40"
+     r="24" />
+  <path
+     style="font-variation-settings:normal;opacity:1;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     d="M 23.029437,56.970563 56.970563,23.029437"
+     id="path7385" />
+</svg>


### PR DESCRIPTION
This pull request adds a feature to display an icon indicating whether a measurement is complete or was interrupted. The icons look like this:
![image](https://user-images.githubusercontent.com/6262159/219638124-908110d2-4932-4321-8d2e-ba4a3bb72a85.png)

How it works:
When a `DDH5Writer` exits, either a `__complete__` tag or an `__interrupted__` tag is created depending on whether the exit is due to an exception or not. Monitr treats the `__complete__` and `__interrupted__` tags like the `__star__` and `__trash__` tags and displays an icon. In this implementation, `__star__` and `__trash__` takes precedence over `__complete__` and `__interrupted__`.