### PR TITLE
Fix the wrong selection of AppendMode in DDH5Writer.add_data

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -587,7 +587,6 @@ class DDH5Writer(object):
 
         self.basedir = Path(basedir)
         self.datadict = datadict
-        self.inserted_rows = 0
 
         if name is None:
             name = ''
@@ -615,7 +614,6 @@ class DDH5Writer(object):
                              groupname=self.groupname,
                              append_mode=AppendMode.none,
                              file_timeout=self.file_timeout)
-            self.inserted_rows = nrecords
         return self
 
     def __exit__(self,
@@ -671,16 +669,10 @@ class DDH5Writer(object):
         an outer dimension with length 1 is added for all.
         """
         self.datadict.add_data(**kwargs)
-
-        if self.inserted_rows > 0:
-            mode = AppendMode.new
-        else:
-            mode = AppendMode.none
         nrecords = self.datadict.nrecords()
         if nrecords is not None and nrecords > 0:
             datadict_to_hdf5(self.datadict, str(self.filepath),
                              groupname=self.groupname,
-                             append_mode=mode,
                              file_timeout=self.file_timeout)
 
             assert self.filepath is not None


### PR DESCRIPTION
Currently, `DDH5Writer.add_data` selects the `AppendMode` according to `DDH5Writer.inserted_rows`, which is not incremented correctly.
Because of this, `DDH5Writer.add_data` always selects `AppendMode.none` and unnecessarily re-creates the ddh5 file every time a row of data is added.
This bugfix removes the part where `DDH5Writer.add_data` incorrectly sets the `AppendMode` and lets `datadict_to_hdf5` decide whether to re-create or append to the ddh5 file.
I have also removed `DDH5Writer.inserted_rows` because it is not used anywhere else.