### PR TITLE
Feature: Find datadicts matching a set of conditions

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -562,7 +562,7 @@ class DDH5Writer(object):
     :param basedir: The root directory in which data is stored.
         :meth:`.create_file_structure` is creating the structure inside this root and
         determines the file name of the data. The default structure implemented here is
-        ``<root>/YYYY-MM-DD/YYYY-mm-ddTHHMMSS_<ID>-<name>/<filename>.ddh5``,
+        ``<root>/YYYY-mm-dd/YYYY-mm-ddTHHMMSS_<ID>-<name>/<filename>.ddh5``,
         where <ID> is a short identifier string and <name> is the value of parameter `name`.
         To change this, re-implement :meth:`.data_folder` and/or
         :meth:`.create_file_structure`.
@@ -642,7 +642,7 @@ class DDH5Writer(object):
         be saved.
 
         Default format:
-        ``<basedir>/YYYY-MM-DD/YYYY-mm-ddTHHMMSS_<ID>-<name>``.
+        ``<basedir>/YYYY-mm-dd/YYYY-mm-ddTHHMMSS_<ID>-<name>``.
         In this implementation we use the first 8 characters of a UUID as ID.
 
         :returns: The folder path.
@@ -739,8 +739,9 @@ def search_datadicts(
     """Iterate over datadicts matching a set of conditions.
 
     :param basedir: The root directory in which data is stored.
-    :param since: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`).
-    :param until: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`). Defaults to `since`.
+    :param since: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`).
+    :param until: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`).
+        If not given, default to `until = since`.
     :param name: Name of the dataset (if not given, match all datasets).
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
@@ -787,8 +788,9 @@ def search_datadict(
     `AssertionError` is raised if there are zero or multiple matching datadicts.
 
     :param basedir: The root directory in which data is stored.
-    :param since: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`).
-    :param until: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`). Defaults to `since`.
+    :param since: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`).
+    :param until: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`).
+        If not given, default to `until = since`.
     :param name: Name of the dataset (if not given, match all datasets).
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -735,6 +735,8 @@ def search_datadicts(
     groupname: str = 'data',
     filename: str = 'data',
     structure_only: bool = False,
+    only_complete: bool = True,
+    skip_trash: bool = True,
 ) -> Iterator[Tuple[str, DataDict]]:
     """Iterate over datadicts matching a set of conditions.
 
@@ -746,6 +748,8 @@ def search_datadicts(
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
     :param structure_only: If `True`, don't load the data values.
+    :param only_complete: If `True`, only return datadicts tagged as complete.
+    :param skip_trash: If `True`, skip datadicts tagged as trash.
     :return: Iterator over (foldername, datadict).
     """
     basedir = Path(basedir)
@@ -765,6 +769,10 @@ def search_datadicts(
                 continue
             if not (since <= foldername[:len(since)] <= until):
                 continue
+            if only_complete and not ((folder_path / "__complete__.tag").is_file()):
+                continue
+            if skip_trash and (folder_path / "__trash__.tag").is_file():
+                continue
             datadict = datadict_from_hdf5(
                 folder_path / filename,
                 groupname,
@@ -782,6 +790,8 @@ def search_datadict(
     groupname: str = 'data',
     filename: str = 'data',
     structure_only: bool = False,
+    only_complete: bool = True,
+    skip_trash: bool = True,
     newest: bool = False,
 ) -> Tuple[str, DataDict]:
     """Find the datadict which matches a set of conditions.
@@ -795,6 +805,8 @@ def search_datadict(
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
     :param structure_only: If `True`, don't load the data values.
+    :param only_complete: If `True`, only return datadicts tagged as complete.
+    :param skip_trash: If `True`, skip datadicts tagged as trash.
     :param newest: If `True`, return the newest matching datadict
     :return: (foldername, datadict).
     """
@@ -806,6 +818,8 @@ def search_datadict(
         groupname=groupname,
         filename=filename,
         structure_only=structure_only,
+        only_complete=only_complete,
+        skip_trash=skip_trash,
     ))
     assert len(result) > 0, "no matching datadict found"
     if not newest:

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -7,6 +7,7 @@ Provides file-storage tools for the DataDict class.
     The lock file has the following format: ~<file_name>.lock. The file lock will get deleted even if the program
     crashes. If the process is suddenly stopped however, we cannot guarantee that the file lock will be deleted.
 """
+from operator import itemgetter
 import os
 import logging
 import time
@@ -780,6 +781,7 @@ def search_datadict(
     groupname: str = 'data',
     filename: str = 'data',
     structure_only: bool = False,
+    newest: bool = False,
 ) -> Tuple[str, DataDict]:
     """Find the datadict which matches a set of conditions.
     `AssertionError` is raised if there are zero or multiple matching datadicts.
@@ -791,6 +793,7 @@ def search_datadict(
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
     :param structure_only: If `True`, don't load the data values.
+    :param newest: If `True`, return the newest matching datadict
     :return: (foldername, datadict).
     """
     result = list(search_datadicts(
@@ -802,5 +805,7 @@ def search_datadict(
         filename=filename,
         structure_only=structure_only,
     ))
-    assert len(result) == 1, f"{len(result)} matching datadicts found"
-    return result[0]
+    assert len(result) > 0, "no matching datadict found"
+    if not newest:
+        assert len(result) == 1, f"{len(result)} matching datadicts found"
+    return max(result, key=itemgetter(0))

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -280,7 +280,7 @@ def datadict_from_hdf5(path: Union[str, Path],
 
             if stopidx is None or stopidx > min(lens):
                 stopidx = min(lens)
-        else:
+        elif len(set(lens)) == 1:
             if stopidx is None or stopidx > lens[0]:
                 stopidx = lens[0]
 

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -727,19 +727,20 @@ class DDH5Writer(object):
 
 
 def search_datadicts(
+    basedir: Union[str, Path],
     since: str,
     until: Optional[str] = None,
     name: Optional[str] = None,
-    basedir: Union[str, Path] = '.',
     groupname: str = 'data',
     filename: str = 'data',
     structure_only: bool = False,
 ) -> Iterator[Tuple[str, DataDict]]:
     """Iterate over datadicts matching a set of conditions.
+
+    :param basedir: The root directory in which data is stored.
     :param since: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`).
     :param until: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`). Defaults to `since`.
     :param name: Name of the dataset (if not given, match all datasets).
-    :param basedir: The root directory in which data is stored.
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
     :param structure_only: If `True`, don't load the data values.
@@ -772,30 +773,31 @@ def search_datadicts(
 
 
 def search_datadict(
+    basedir: Union[str, Path],
     since: str,
     until: Optional[str] = None,
     name: Optional[str] = None,
-    basedir: Union[str, Path] = '.',
     groupname: str = 'data',
     filename: str = 'data',
     structure_only: bool = False,
 ) -> Tuple[str, DataDict]:
     """Find the datadict which matches a set of conditions.
     `AssertionError` is raised if there are zero or multiple matching datadicts.
+
+    :param basedir: The root directory in which data is stored.
     :param since: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`).
     :param until: Date (and time) in the format `YYYY-MM-DD` (or `YYYY-mm-ddTHHMMSS`). Defaults to `since`.
     :param name: Name of the dataset (if not given, match all datasets).
-    :param basedir: The root directory in which data is stored.
     :param groupname: Name of hdf5 group.
     :param filename: Name of the ddh5 file without the extension.
     :param structure_only: If `True`, don't load the data values.
     :return: (foldername, datadict).
     """
     result = list(search_datadicts(
+        basedir,
         since,
         until=until,
         name=name,
-        basedir=basedir,
         groupname=groupname,
         filename=filename,
         structure_only=structure_only,


### PR DESCRIPTION
This pull request adds a method `plottr.data.datadict_storage.search_datadicts`, which returns an iterator over datadicts matching a set of conditions.
The following conditions are currently supported:
- `since`: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`).
- `until`: Date (and time) in the format `YYYY-mm-dd` (or `YYYY-mm-ddTHHMMSS`). If not given, default to `until = since`.
- `name`: Name of the dataset (if not given, match all datasets).

For convenience, I've also added a method `plottr.data.datadict_storage.search_datadict`, which asserts that there is only one matching datadict.