### PR TITLE
Fix a bug in DDH5Writer.__exit__

### DIFF
--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -628,7 +628,7 @@ class DDH5Writer(object):
                  exc_traceback: Optional[TracebackType]) -> None:
         assert self.filepath is not None
         with FileOpener(self.filepath, 'a', timeout=self.file_timeout) as f:
-            add_cur_time_attr(f[self.groupname], name='close')
+            add_cur_time_attr(f.require_group(self.groupname), name='close')
         if exc_type is None:
             # exiting because the measurement is complete
             self.add_tag('__complete__')


### PR DESCRIPTION
Currently, if an exception is raised inside a `with DDH5Writer` block before any data is added, `DDH5Writer.__exit__` tries to add a metadata to the ddh5 file and fails because the ddh5 file doesn't have a group named `data` yet.
This pull request fixes this bug by creating a group named `data` if it doesn't exist.