### PR TITLE
Install pyzmq on `pip install plottr`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     versioningit>=1.1.0
     psutil
     watchdog
+    pyzmq
 
 [options.package_data]
 plottr =


### PR DESCRIPTION
`pyzmq` is required by `plottr` but is not installed on `pip install plottr`.
This is fixed by this pull request.