### PR TITLE
fix: incomplete data

### DIFF
--- a/plottr/data/datadict.py
+++ b/plottr/data/datadict.py
@@ -1086,6 +1086,11 @@ class MeshgridDataDict(DataDictBase):
                         try:
                             if axis_data.shape[axis_num] > 1:
                                 steps = np.unique(np.sign(np.diff(axis_data, axis=axis_num)))
+                                
+                                # for incomplete data, there maybe nan steps -- we need to remove those, 
+                                # doesn't mean anything is wrong.
+                                steps = steps[~np.isnan(steps)]
+                                
                                 if 0 in steps:
                                     msg += (f"Malformed data: {na} is expected to be {axis_num}th "
                                             "axis but has no variation along that axis.\n")

--- a/test/apps/autoplot_app.py
+++ b/test/apps/autoplot_app.py
@@ -24,7 +24,7 @@ from plottr.plot.mpl.autoplot import AutoPlot as MPLAutoPlot
 from plottr.plot.pyqtgraph.autoplot import AutoPlot as PGAutoPlot
 from plottr.utils import testdata
 
-plottrlog.enableStreamHandler(True)
+plottrlog.enableStreamHandler(True, level=logging.DEBUG)
 logger = plottrlog.getLogger('plottr.test.autoplot_app')
 
 
@@ -161,7 +161,7 @@ plotWidgetClass = PGAutoPlot
 if __name__ == '__main__':
     # src = LineDataMovie(20, 3, 31)
     # src = ImageDataMovie(10, 2, 101)
-    # src = ImageDataLiveAcquisition(101, 101, 67)
-    src = ComplexImage(21, 21)
+    src = ImageDataLiveAcquisition(101, 101, 67)
+    # src = ComplexImage(21, 21)
     src.delay = 0.1
     main(src)


### PR DESCRIPTION
when data is incomplete, 'nan' steps appear in axes, which is fine. was incorrectly seen as malformed data.