### PR TITLE
extended the maximum refreshing number to 1000 instead of 100

### DIFF
--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -87,6 +87,7 @@ class UpdateToolBar(QtWidgets.QToolBar):
         super().__init__(name, parent)
 
         self.monitorInput = MonitorIntervalInput()
+        self.monitorInput.spin.setMaximum(1000)
         self.monitorInput.setToolTip('Set to 0 for disabling triggering')
         self.monitorInput.intervalChanged.connect(self.setMonitorInterval)
         self.addWidget(self.monitorInput)


### PR DESCRIPTION
extended the maximum refreshing number to 1000 instead of 100 in an autoplot window.

This change is to address issue #43.

If this is not a good idea we should close that issue

closes #43 