### PR TITLE
Drop support for python 3.9 and 3.8

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       DISPLAY: ':99.0'
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.3.0
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - uses: ./.github/actions/install-dependencies-and-plottr
     - name: Install build deps
       run: pip install --upgrade build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -20,7 +18,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "pandas>=0.22",
     "xarray",


### PR DESCRIPTION
Many scientific packages follow spec 0 https://scientific-python.org/specs/spec-0000/ and have dropped support for these python versions. It makes sense to also do this here