### PR TITLE
Use read_only flag to load qcodes dataset

### DIFF
--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -579,7 +579,10 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
     @Slot(int)
     def setRunSelection(self, runId: int) -> None:
         assert self.filepath is not None
-        ds = load_dataset_from(self.filepath, runId)
+        if sys.version_info >= (3, 11):
+            ds = load_dataset_from(self.filepath, runId, read_only=True)
+        else:
+            ds = load_dataset_from(self.filepath, runId)
         snap = None
         if hasattr(ds, 'snapshot'):
             snap = ds.snapshot

--- a/plottr/apps/inspectr.py
+++ b/plottr/apps/inspectr.py
@@ -610,7 +610,10 @@ class QCodesDBInspector(QtWidgets.QMainWindow):
         # set tag in the database
         assert self.filepath is not None
         runId = int(item.text(0))
-        ds = load_dataset_from(self.filepath, runId)
+        if sys.version_info >= (3, 11):
+            ds = load_dataset_from(self.filepath, runId, read_only=False)
+        else:
+            ds = load_dataset_from(self.filepath, runId)
         ds.add_metadata('inspectr_tag', tag)
 
         # set tag in self.dbdf

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -4,6 +4,7 @@ qcodes_dataset.py
 Dealing with qcodes dataset (the database) data in plottr.
 """
 import os
+import sys
 from itertools import chain
 from operator import attrgetter
 from typing import Dict, List, Set, Union, TYPE_CHECKING, Any, Tuple, Optional, cast
@@ -14,7 +15,7 @@ import pandas as pd
 
 from qcodes.dataset.data_set import load_by_id
 from qcodes.dataset.experiment_container import experiments
-from qcodes.dataset.sqlite.database import initialise_or_create_database_at
+from qcodes.dataset.sqlite.database import conn_from_dbpath_or_conn, initialise_or_create_database_at
 
 from .datadict import DataDictBase, DataDict, combine_datadicts
 from ..node.node import Node, updateOption
@@ -160,7 +161,7 @@ def get_ds_info(ds: 'DataSetProtocol', get_structure: bool = True) -> DataSetInf
     return data
 
 
-def load_dataset_from(path: str, run_id: int) -> 'DataSetProtocol':
+def load_dataset_from(path: str, run_id: int, read_only: bool = False) -> 'DataSetProtocol':
     """
     Loads ``DataSet`` with the given ``run_id`` from a database file that
     is located in in the given ``path``.
@@ -169,6 +170,8 @@ def load_dataset_from(path: str, run_id: int) -> 'DataSetProtocol':
     qcodes config of the current python process is changed to ``path``.
     """
     initialise_or_create_database_at(path)
+    if sys.version_info >= (3, 11):
+        return load_by_id(run_id=run_id, read_only=read_only)
     return load_by_id(run_id=run_id)
 
 
@@ -187,9 +190,14 @@ def get_runs_from_db(path: str, start: int = 0,
     in the return dict.
     """
     initialise_or_create_database_at(path)
+    if sys.version_info >= (3, 11):
+        conn = conn_from_dbpath_or_conn(read_only=True)
+    else:
+        conn = conn_from_dbpath_or_conn()
+    exps = experiments(conn=conn)
 
     datasets = sorted(
-        chain.from_iterable(exp.data_sets() for exp in experiments()),
+        chain.from_iterable(exp.data_sets() for exp in exps),
         key=attrgetter('run_id')
     )
 
@@ -286,7 +294,7 @@ class QCodesDSLoader(Node):
             path, runId = cast(Tuple[str, int], self._pathAndId)
 
             if self._dataset is None:
-                self._dataset = load_dataset_from(path, runId)
+                self._dataset = load_dataset_from(path, runId, read_only=True)
 
             if self._dataset.number_of_results > self.nLoadedRecords:
 

--- a/plottr/data/qcodes_dataset.py
+++ b/plottr/data/qcodes_dataset.py
@@ -161,7 +161,7 @@ def get_ds_info(ds: 'DataSetProtocol', get_structure: bool = True) -> DataSetInf
     return data
 
 
-def load_dataset_from(path: str, run_id: int, read_only: bool = False) -> 'DataSetProtocol':
+def load_dataset_from(path: str, run_id: int, read_only: bool = True) -> 'DataSetProtocol':
     """
     Loads ``DataSet`` with the given ``run_id`` from a database file that
     is located in in the given ``path``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ Tracker = "https://github.com/toolsforexperiments/plottr/issues"
 pyqt5 = ["PyQt5"]
 pyqt6 = ["PyQt6"]
 pyside2 = ["PySide2>=5.12"]
-qcodes = ["qcodes"]
+qcodes = ["qcodes>=0.54.1"]
 
 [project.scripts]
 plottr-monitr = "plottr.apps.monitr:script"


### PR DESCRIPTION
This PR updates the qcodes dataset loading logic to use the read_only flag when calling load_by_id and when connecting to the database.

This feature is available from qcodes 0.54.1 onwards which requires Python 3.11+.