### PR TITLE
Drop Python 3.10 and 3.11, set minimum to 3.12

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     env:
       DISPLAY: ':99.0'
 

--- a/doc/examples/Inferring grids.ipynb
+++ b/doc/examples/Inferring grids.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "from plottr.data import datadict as dd\n",
     "from plottr.utils import num\n",
-    "from plottr.utils.num import _find_switches, is_invalid\n",
+    "from plottr.utils.num import _find_switches\n",
     "from plottr.plot.mpl import ppcolormesh_from_meshgrid\n",
     "\n",
     "\n",

--- a/doc/examples/Simple Live plotting example with DDH5.ipynb
+++ b/doc/examples/Simple Live plotting example with DDH5.ipynb
@@ -12,7 +12,6 @@
    "outputs": [],
    "source": [
     "import time\n",
-    "import os\n",
     "import numpy as np\n",
     "\n",
     "from plottr.data import datadict as dd\n",

--- a/doc/examples/node_with_dimension_selector_widget.py
+++ b/doc/examples/node_with_dimension_selector_widget.py
@@ -10,9 +10,8 @@ This example does the following:
 from typing import List, Optional
 from pprint import pprint
 
-import numpy as np
 
-from plottr import QtCore, QtWidgets, Signal, Slot
+from plottr import QtWidgets
 from plottr.data import DataDict
 from plottr.node.node import Node, NodeWidget, updateOption, updateGuiQuietly
 from plottr.node.tools import linearFlowchart

--- a/plottr/analyzer/base.py
+++ b/plottr/analyzer/base.py
@@ -1,12 +1,7 @@
-from typing import Tuple, Any, Optional, Union, Dict, List
+from typing import Tuple, Any, Union, Dict
 from collections import OrderedDict
-from dataclasses import dataclass
-from pathlib import Path
-import json
 
 import numpy as np
-from matplotlib import pyplot as plt
-import lmfit
 
 
 class Parameter:

--- a/plottr/analyzer/fitters/experiment_functions.py
+++ b/plottr/analyzer/fitters/experiment_functions.py
@@ -1,8 +1,7 @@
-from typing import Tuple, Any, Optional, Union, Dict, List
+from typing import Tuple, Any, Union, Dict
 
 import numpy as np
-import lmfit
-from plottr.analyzer.fitters.fitter_base  import Fit, FitResult
+from plottr.analyzer.fitters.fitter_base  import Fit
 
 
 class T1_Decay(Fit):

--- a/plottr/analyzer/fitters/generic_functions.py
+++ b/plottr/analyzer/fitters/generic_functions.py
@@ -1,9 +1,8 @@
-from typing import Tuple, Any, Optional, Union, Dict, List
+from typing import Tuple, Union, Dict
 
 import numpy as np
-import lmfit
 
-from plottr.analyzer.fitters.fitter_base import Fit, FitResult
+from plottr.analyzer.fitters.fitter_base import Fit
 
 
 class Cosine(Fit):

--- a/plottr/apps/appmanager.py
+++ b/plottr/apps/appmanager.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Dict, Union, Any, Callable, Tuple, Optional
 
 from traceback import print_exception
-from plottr import QtCore, QtWidgets, QtGui, Flowchart, Signal, Slot, log, qtapp, qtsleep, plottrPath
+from plottr import QtCore, QtWidgets, QtGui, Flowchart, Signal, Slot, log, qtsleep, plottrPath
 from plottr.gui.widgets import PlotWindow
 
 

--- a/plottr/apps/autoplot.py
+++ b/plottr/apps/autoplot.py
@@ -10,12 +10,11 @@ from typing import Union, Tuple, Optional, Type, List, Any, Type
 from packaging import version
 
 from .. import QtCore, Flowchart, Signal, Slot, QtWidgets, QtGui
-from .. import log as plottrlog
 from ..data.datadict import DataDictBase
 from ..data.datadict_storage import DDH5Loader
 from ..data.qcodes_dataset import QCodesDSLoader
 from ..gui import PlotWindow
-from ..gui.widgets import MonitorIntervalInput, SnapshotWidget
+from ..gui.widgets import MonitorIntervalInput
 from ..node.data_selector import DataSelector
 from ..node.dim_reducer import XYSelector
 from ..node.filter.correct_offset import SubtractAverage

--- a/plottr/apps/monitr.py
+++ b/plottr/apps/monitr.py
@@ -1,11 +1,9 @@
 """plottr.monitr -- a GUI tool for monitoring data files."""
 
-import copy
 import sys
 import os
 import argparse
 import time
-import importlib
 
 # Uncomment the next 2 lines if the app suddenly crash with no error.
 # import cgitb
@@ -17,7 +15,6 @@ import pprint
 import json
 from enum import Enum, auto
 from pathlib import Path
-from multiprocessing import Process
 from typing import (
     List,
     Optional,
@@ -25,7 +22,6 @@ from typing import (
     Any,
     Union,
     Generator,
-    Iterable,
     Tuple,
     Sequence,
     cast,
@@ -35,14 +31,12 @@ from itertools import cycle
 
 from watchdog.events import FileSystemEvent, FileSystemMovedEvent
 
-from .. import log as plottrlog
 from .. import QtCore, QtWidgets, Signal, Slot, QtGui, plottrPath
 from .. import config_entry as getcfg
 from ..plot.mpl.autoplot import AutoPlot as MPLAutoPlot
 from ..plot.pyqtgraph.autoplot import AutoPlot as PGAutoPlot
-from ..data.datadict_storage import all_datadicts_from_hdf5, datadict_from_hdf5
+from ..data.datadict_storage import datadict_from_hdf5
 from ..data.datadict import DataDict
-from ..utils.misc import unwrap_optional
 from ..apps.watchdog_classes import WatcherClient
 from ..gui.widgets import Collapsible
 from .json_viewer import JsonModel, JsonTreeView

--- a/plottr/apps/ui/Monitr_UI.py
+++ b/plottr/apps/ui/Monitr_UI.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from plottr import QtCore, QtGui, QtWidgets
+from plottr import QtCore, QtWidgets
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow: QtWidgets.QMainWindow) -> None:

--- a/plottr/apps/ui/monitr.py
+++ b/plottr/apps/ui/monitr.py
@@ -1,7 +1,5 @@
 import os
-from enum import Enum
-from typing import List, Any, Optional, Dict, Sequence, Union
-from pprint import pprint
+from typing import List, Optional, Dict, Sequence, Union
 
 from plottr import QtCore, QtGui, QtWidgets, Slot, Signal
 from plottr.data.datadict import DataDict

--- a/plottr/config/plottrcfg_main.py
+++ b/plottr/config/plottrcfg_main.py
@@ -1,5 +1,4 @@
 from matplotlib.rcsetup import cycler
-from plottr.plot.pyqtgraph.autoplot import AutoPlot as PGAutoPlot
 from plottr.plot.mpl.autoplot import AutoPlot as MPLAutoPlot
 
 config = {

--- a/plottr/data/datadict_storage.py
+++ b/plottr/data/datadict_storage.py
@@ -23,11 +23,10 @@ import numpy as np
 import h5py
 
 from qcodes.utils import NumpyJSONEncoder
-from plottr import QtGui, Signal, Slot, QtWidgets, QtCore
+from plottr import Signal, Slot, QtWidgets, QtCore
 
 from ..node import (
-    Node, NodeWidget, updateOption, updateGuiFromNode,
-    emitGuiUpdate,
+    Node, NodeWidget, updateOption,
 )
 
 from .datadict import DataDict, is_meta_key, DataDictBase

--- a/plottr/gui/data_display.py
+++ b/plottr/gui/data_display.py
@@ -3,9 +3,9 @@
 UI elements for inspecting data structure and content.
 """
 
-from typing import Union, List, Tuple, Dict, Any, Optional
+from typing import List, Tuple, Dict, Any, Optional
 
-from .. import QtCore, QtWidgets, Signal, Slot
+from .. import QtWidgets, Signal, Slot
 from ..data.datadict import DataDictBase
 
 

--- a/plottr/gui/widgets.py
+++ b/plottr/gui/widgets.py
@@ -6,8 +6,8 @@ Common GUI widgets that are re-used across plottr.
 from typing import Union, List, Tuple, Optional, Sequence, Dict, Any, Type, Generic, TypeVar
 
 from .tools import dictToTreeWidgetItems, dpiScalingFactor
-from plottr import QtGui, QtCore, Flowchart, QtWidgets, Signal, Slot
-from plottr.node import Node, linearFlowchart, NodeWidget, updateOption
+from plottr import QtGui, Flowchart, QtWidgets, Signal, Slot
+from plottr.node import Node, linearFlowchart
 from plottr.node.node import updateGuiQuietly, emitGuiUpdate
 from ..plot import PlotNode, PlotWidgetContainer, PlotWidget
 from .. import config_entry as getcfg

--- a/plottr/icons.py
+++ b/plottr/icons.py
@@ -1,5 +1,5 @@
 import os
-from plottr import QtGui, QtCore, plottrPath
+from plottr import QtGui, plottrPath
 
 gfxPath = os.path.join(plottrPath, 'resource', 'gfx')
 

--- a/plottr/node/autonode.py
+++ b/plottr/node/autonode.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any, Callable, Optional, Type, cast
 
-from .. import QtGui, QtWidgets
+from .. import QtWidgets
 from .node import Node, NodeWidget, updateOption
 
 connectCallableType = Callable[['AutoNodeGuiTemplate', str, Dict[str, Any], bool], QtWidgets.QWidget]

--- a/plottr/node/data_selector.py
+++ b/plottr/node/data_selector.py
@@ -5,7 +5,6 @@ A node and widget for subselecting from a dataset.
 """
 from typing import List, Tuple, Dict, Any, Sequence, Optional
 
-import numpy as np
 
 from .node import Node, NodeWidget, updateOption
 from ..data.datadict import DataDictBase, DataDict

--- a/plottr/node/filter/correct_offset.py
+++ b/plottr/node/filter/correct_offset.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional, Dict
+from typing import Optional, Dict
 
 import numpy as np
 

--- a/plottr/node/fitter.py
+++ b/plottr/node/fitter.py
@@ -1,19 +1,15 @@
 import sys
-import os
 import pkgutil
-import importlib
-from importlib import reload, import_module
-import warnings
-from typing import Dict, Optional, Type, Callable, Tuple, Any, List, Union
+from importlib import import_module
+from typing import Dict, Optional, Type, Tuple, Any, List, Union
 import inspect
 from dataclasses import dataclass
 import numbers
 from types import ModuleType
 
-import lmfit
 from lmfit import Parameter as lmParameter, Parameters as lmParameters
 
-from plottr import QtGui, QtCore, Slot, Signal, QtWidgets
+from plottr import QtCore, Slot, Signal, QtWidgets
 from plottr.analyzer import fitters
 from plottr.analyzer.fitters.fitter_base import Fit, FitResult
 

--- a/plottr/node/grid.py
+++ b/plottr/node/grid.py
@@ -9,7 +9,7 @@ from typing import Tuple, Dict, Any, List, Optional, Sequence, cast
 
 from typing_extensions import TypedDict
 
-from plottr import QtGui, Signal, Slot, QtWidgets
+from plottr import Signal, Slot, QtWidgets
 from .node import Node, NodeWidget, updateOption, updateGuiFromNode
 from ..data import datadict as dd
 from ..data.datadict import DataDict, MeshgridDataDict, DataDictBase, GriddingError

--- a/plottr/node/node.py
+++ b/plottr/node/node.py
@@ -12,7 +12,7 @@ from typing import Any, Union, Tuple, Dict, Optional, Type, List, Callable, Type
 
 from .. import NodeBase
 from .. import QtGui, QtCore, Signal, Slot, QtWidgets
-from ..data.datadict import DataDictBase, MeshgridDataDict
+from ..data.datadict import DataDictBase
 from .. import log
 
 __author__ = 'Wolfgang Pfaff'

--- a/plottr/plot/mpl/widgets.py
+++ b/plottr/plot/mpl/widgets.py
@@ -5,7 +5,6 @@
 import io
 from typing import Tuple, Optional, List, Dict
 
-from numpy import rint
 from matplotlib import rcParams
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure

--- a/plottr/plot/pyqtgraph/plots.py
+++ b/plottr/plot/pyqtgraph/plots.py
@@ -1,7 +1,7 @@
 """Convenience tools for generating ``pyqtgraph`` plots that can
 be used in plottr's automatic plotting framework."""
 
-from typing import Optional, Tuple, NoReturn
+from typing import Optional, Tuple
 
 import numpy as np
 import pyqtgraph as pg

--- a/plottr/utils/num.py
+++ b/plottr/utils/num.py
@@ -2,7 +2,7 @@
 
 Tools for numerical operations.
 """
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "pandas>=0.22",
     "xarray",

--- a/test/apps/autoplot_app.py
+++ b/test/apps/autoplot_app.py
@@ -20,7 +20,6 @@ from plottr import QtCore, QtWidgets, Signal
 from plottr import log as plottrlog
 from plottr.apps.autoplot import autoplot
 from plottr.data.datadict import DataDictBase, DataDict
-from plottr.plot.mpl.autoplot import AutoPlot as MPLAutoPlot
 from plottr.plot.pyqtgraph.autoplot import AutoPlot as PGAutoPlot
 from plottr.utils import testdata
 

--- a/test/apps/fitter_test.py
+++ b/test/apps/fitter_test.py
@@ -4,8 +4,8 @@ Testing how to make a custom app with gui.
 import numpy as np
 import lmfit
 
-from plottr import QtGui, QtWidgets
-from plottr.data.datadict import DataDictBase, MeshgridDataDict
+from plottr import QtWidgets
+from plottr.data.datadict import MeshgridDataDict
 from plottr.gui.widgets import makeFlowchartWithPlotWindow
 from plottr.node.dim_reducer import XYSelector
 from plottr.node.fitter import FittingNode, FittingOptions

--- a/test/apps/test_histograms.py
+++ b/test/apps/test_histograms.py
@@ -12,11 +12,7 @@ ipy.magic("matplotlib qt")
 from typing import Tuple
 
 import numpy as np
-from matplotlib import pyplot as plt
-from xhistogram.core import histogram
 
-from plottr.data.datadict import datadict_to_meshgrid
-from plottr.node.tools import linearFlowchart
 from plottr import Flowchart, QtCore
 from plottr.data import DataDict
 from plottr.apps.autoplot import AutoPlotMainWindow

--- a/test/gui/data_display_widgets.py
+++ b/test/gui/data_display_widgets.py
@@ -3,7 +3,6 @@
 Testing scripts for GUI elements for data display.
 """
 
-from plottr import QtWidgets
 from plottr.gui.tools import widgetDialog
 from plottr.gui.data_display import DataSelectionWidget
 from plottr.utils import testdata

--- a/test/gui/data_selector.py
+++ b/test/gui/data_selector.py
@@ -1,4 +1,4 @@
-from plottr import QtGui, QtWidgets
+from plottr import QtWidgets
 from plottr.gui.tools import widgetDialog
 from plottr.node.data_selector import DataSelector
 from plottr.node.tools import linearFlowchart

--- a/test/gui/dimension_selection_widgets.py
+++ b/test/gui/dimension_selection_widgets.py
@@ -1,9 +1,7 @@
-import argparse
-from typing import Tuple
 
 from plottr import QtWidgets
 from plottr.data.datadict import str2dd
-from plottr.gui.widgets import AxisSelector, DependentSelector, DimensionSelector, \
+from plottr.gui.widgets import DimensionSelector, \
     MultiDimensionSelector
 from plottr.gui.tools import widgetDialog
 

--- a/test/gui/grid_options.py
+++ b/test/gui/grid_options.py
@@ -3,7 +3,6 @@
 Testing Widgets for the gridding node.
 """
 
-from plottr import QtGui
 from plottr.data.datadict import datadict_to_meshgrid
 from plottr.gui.tools import widgetDialog
 from plottr.node.grid import GridOptionWidget, ShapeSpecificationWidget, DataGridder, GridOption

--- a/test/gui/pyqtgraph_testing.py
+++ b/test/gui/pyqtgraph_testing.py
@@ -7,7 +7,7 @@ import sys
 import numpy as np
 import pyqtgraph as pg
 
-from plottr import QtWidgets, QtGui, QtCore
+from plottr import QtWidgets, QtCore
 from plottr.gui.tools import widgetDialog
 
 pg.setConfigOption('background', 'w')

--- a/test/gui/simple_2d_plot.py
+++ b/test/gui/simple_2d_plot.py
@@ -3,7 +3,7 @@ import time
 
 from plottr import QtWidgets
 from plottr import log
-from plottr.data.datadict import DataDict, datadict_to_meshgrid
+from plottr.data.datadict import datadict_to_meshgrid
 from plottr.utils import testdata
 from plottr.gui import PlotWindow
 from plottr.plot.mpl import AutoPlot

--- a/test/prototyping/new_data_methods.ipynb
+++ b/test/prototyping/new_data_methods.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plottr.data.datadict import DataDict, MeshgridDataDict"
+    "from plottr.data.datadict import MeshgridDataDict"
    ]
   },
   {

--- a/test/prototyping/test_data.py
+++ b/test/prototyping/test_data.py
@@ -2,9 +2,7 @@ from typing import Tuple
 import numpy as np
 
 
-from plottr.apps.autoplot import autoplot
-from plottr.plot.pyqtgraph.autoplot import AutoPlot
-from plottr.data.datadict import DataDict, MeshgridDataDict
+from plottr.data.datadict import MeshgridDataDict
 
 
 def oscillating_test_data(*specs: Tuple[float, float, int], amp=1, of=0):

--- a/test/pytest/test_app_manager.py
+++ b/test/pytest/test_app_manager.py
@@ -7,9 +7,8 @@ import zmq
 
 from plottr.data.datadict import DataDictBase, DataDict
 from plottr.data.datadict_storage import datadict_to_hdf5
-from plottr import QtWidgets, QtCore, plottrPath
 from plottr.apps.appmanager import AppManager
-from plottr import qtapp, qtsleep
+from plottr import qtsleep
 
 # Module where the launching function lives.
 MODULE = 'plottr.apps.autoplot'

--- a/test/pytest/test_correct_offset.py
+++ b/test/pytest/test_correct_offset.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from plottr.data.datadict import MeshgridDataDict, DataDict
+from plottr.data.datadict import MeshgridDataDict
 from plottr.node.tools import linearFlowchart
 from plottr.node.filter.correct_offset import SubtractAverage
 from plottr.utils import num

--- a/test/pytest/test_gridder.py
+++ b/test/pytest/test_gridder.py
@@ -1,9 +1,8 @@
 import numpy as np
 
-from plottr.data.datadict import MeshgridDataDict, DataDict
+from plottr.data.datadict import DataDict
 from plottr.node.tools import linearFlowchart
 from plottr.node.grid import DataGridder, GridOption
-from plottr.utils import testdata
 from plottr.utils import num
 
 

--- a/test/pytest/test_monitr_filtering.py
+++ b/test/pytest/test_monitr_filtering.py
@@ -10,14 +10,10 @@ First version of filtering testing suite. For now the rules of filtering are:
         will be hidden, no matter if the match with anything else that is being filtered at the moment.
 """
 import os
-import sys
-import time
 import shutil
-import datetime
 import numpy as np
 
 from pathlib import Path
-from pprint import pprint
 from typing import Tuple, List
 
 from plottr.data.datadict import DataDict

--- a/test/pytest/test_numtools.py
+++ b/test/pytest/test_numtools.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/test/pytest/test_qcodes_flow.py
+++ b/test/pytest/test_qcodes_flow.py
@@ -4,7 +4,6 @@ import qcodes as qc
 from numpy.testing import assert_array_equal
 
 
-from plottr.data.datadict import DataDict
 from plottr.node.tools import linearFlowchart
 from plottr.data.qcodes_dataset import QCodesDSLoader
 from plottr.node.data_selector import DataSelector


### PR DESCRIPTION
## Changes
- Set requires-python to >=3.12
- Updated classifiers (removed 3.10 and 3.11)
- Updated CI matrix in python-app.yml (removed 3.10 and 3.11)
- Applied ruff pyupgrade fixes for Python 3.12+ idioms - ended up removing unused imports only